### PR TITLE
change marginToken use to pool.amount in insurance

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -135,28 +135,31 @@ contract Insurance is IInsurance, Ownable {
      */
     function drainPool(address market, uint256 amount) external override onlyAccount() {
         ITracer _tracer = ITracer(market);
+        StakePool storage pool = pools[market];
         IERC20 tracerMarginToken = IERC20(_tracer.tracerBaseToken());
 
         // Enforce a minimum. Very rare as funding rate will be incredibly high at this point
-        if (tracerMarginToken.balanceOf(address(this)) < 10 ** 18) {
+        if (pool.amount < 10 ** 18) {
             return;
         }
 
-        if (amount > tracerMarginToken.balanceOf(address(this))) {
-            amount = tracerMarginToken.balanceOf(address(this));
+        if (amount > pool.amount) {
+            amount = pool.amount;
         }
 
         // What the balance will be after
-        uint256 difference = tracerMarginToken.balanceOf(address(this)) - amount;
+        uint256 difference = pool.amount - amount;
         if (difference < 10 ** 18) {
             // Once we go below one token, social loss is required
             // This calculation caps draining so pool always has at least one token
-            amount = tracerMarginToken.balanceOf(address(this)) - (10 ** 18);
+            amount = pool.amount - (10 ** 18);
+            // Use new amount to compute difference again.
+            difference = pool.amount - amount;
         }
 
         tracerMarginToken.approve(address(account), amount);
         account.deposit(amount, market);
-        pools[market].amount = tracerMarginToken.balanceOf(address(this));
+        pool.amount = difference;
     }
 
     /**

--- a/test-ts/functional/Insurance.ts
+++ b/test-ts/functional/Insurance.ts
@@ -367,7 +367,6 @@ describe("Insurance", async () => {
             await tracer.takeOrder(3, web3.utils.toWei("200"), { from: accounts[3] })
             
             await account.claimReceipts(0, [1, 2, 3], tracer.address, { from: accounts[2] })
-
             let insuranceBalance = await insurance.getPoolHoldings(tracer.address);
             assert.equal(insuranceBalance.toString(), web3.utils.toWei("1"))
         })


### PR DESCRIPTION
# Motivation
There was a potential exploit in the drainPool code that could be used by malicious Tracer markets to drain all of a single token from insurance (all the DAI, not just DAI from an individual pool). This was due to the fact that the drainPool function was referencing the balance of the marginToken for the entire insurance contract, and not just the individual market.

# Changes
- changed references in the drainPool contract from the balance of the insurance contract itself to the pool balance. This way draining is capped to the balance of the pool