### PR TITLE
Update Funding Rate Sensitivity Setter

### DIFF
--- a/contracts/DeployerV1.sol
+++ b/contracts/DeployerV1.sol
@@ -14,7 +14,6 @@ contract DeployerV1 is IDeployer {
     ) external override returns(address) {
         (
             bytes32 _tracerId,
-            uint256 _minMargin,
             address _tracerBaseToken,
             address _oracle,
             address _gasPriceOracle,
@@ -24,7 +23,6 @@ contract DeployerV1 is IDeployer {
             uint256 _fundingRateSensitivity
         ) = abi.decode(_data, (
             bytes32,
-            uint256,
             address,
             address,
             address,
@@ -35,7 +33,6 @@ contract DeployerV1 is IDeployer {
         ));
         Tracer tracer = new Tracer(
             _tracerId,
-            _minMargin,
             _tracerBaseToken,
             _oracle,
             _gasPriceOracle,

--- a/contracts/DeployerV1.sol
+++ b/contracts/DeployerV1.sol
@@ -20,7 +20,8 @@ contract DeployerV1 is IDeployer {
             address _gasPriceOracle,
             address _accountContract,
             address _pricingContract,
-            int256 _maxLeverage
+            int256 _maxLeverage,
+            uint256 _fundingRateSensitivity
         ) = abi.decode(_data, (
             bytes32,
             uint256,
@@ -29,7 +30,8 @@ contract DeployerV1 is IDeployer {
             address,
             address,
             address,
-            int256
+            int256,
+            uint256
         ));
         Tracer tracer = new Tracer(
             _tracerId,
@@ -39,8 +41,9 @@ contract DeployerV1 is IDeployer {
             _gasPriceOracle,
             _accountContract,
             _pricingContract,
-            _maxLeverage
-            );
+            _maxLeverage,
+            _fundingRateSensitivity
+        );
         tracer.transferOwnership(msg.sender);
         return address(tracer);
     }

--- a/contracts/Interfaces/ITracer.sol
+++ b/contracts/Interfaces/ITracer.sol
@@ -77,6 +77,8 @@ interface ITracer {
 
     function setMaxLeverage(int256 _maxLeverage) external;
 
+    function setFundingRateSensitivity(uint256 _fundingRateSensitivity) external;
+
     function transferOwnership(address newOwner) external;
 
     function initializePricing() external;

--- a/contracts/Interfaces/ITracer.sol
+++ b/contracts/Interfaces/ITracer.sol
@@ -36,8 +36,6 @@ interface ITracer {
 
     function priceMultiplier() external view returns(uint256);
 
-    function minMargin() external view returns(uint256);
-
     function feeRate() external view returns(uint256);
 
     function maxLeverage() external view returns(int256);

--- a/contracts/Tracer.sol
+++ b/contracts/Tracer.sol
@@ -28,7 +28,6 @@ contract Tracer is ITracer, SimpleDex, Ownable {
     uint256 public immutable override priceMultiplier;
     address public immutable override tracerBaseToken;
     bytes32 public immutable override marketId;
-    uint256 public immutable override minMargin;
     IAccount public accountContract;
     IPricing public pricingContract;
     uint256 public override feeRate;
@@ -60,7 +59,6 @@ contract Tracer is ITracer, SimpleDex, Ownable {
      * @notice Creates a new tracer market and sets the initial funding rate of the market. Anyone
      *         will be able to purchase and trade tracers after this deployment.
      * @param _marketId the id of the market, given as BASE/QUOTE
-     * @param _minMargin the minimum margin requirement for each account
      * @param _tracerBaseToken the address of the token used for margin accounts (i.e. The margin token)
      * @param _oracle the address of the contract implementing the tracer oracle interface
      * @param _gasPriceOracle the address of the contract implementing gas price oracle
@@ -69,7 +67,6 @@ contract Tracer is ITracer, SimpleDex, Ownable {
      */
     constructor(
         bytes32 _marketId,
-        uint256 _minMargin,
         address _tracerBaseToken,
         address _oracle,
         address _gasPriceOracle,
@@ -81,7 +78,6 @@ contract Tracer is ITracer, SimpleDex, Ownable {
         accountContract = IAccount(_accountContract);
         pricingContract = IPricing(_pricingContract);
         tracerBaseToken = _tracerBaseToken;
-        minMargin = _minMargin;
         oracle = _oracle;
         gasPriceOracle = _gasPriceOracle;
         marketId = _marketId;

--- a/contracts/Tracer.sol
+++ b/contracts/Tracer.sol
@@ -23,7 +23,7 @@ contract Tracer is ITracer, SimpleDex, Ownable {
     using LibMath for int256;
     using SafeERC20 for IERC20;
 
-    uint256 public constant override FUNDING_RATE_SENSITIVITY = 1;
+    uint256 public override FUNDING_RATE_SENSITIVITY;
     uint256 public constant override LIQUIDATION_GAS_COST = 63516;
     uint256 public immutable override priceMultiplier;
     address public immutable override tracerBaseToken;
@@ -75,7 +75,8 @@ contract Tracer is ITracer, SimpleDex, Ownable {
         address _gasPriceOracle,
         address _accountContract,
         address _pricingContract,
-        int256 _maxLeverage
+        int256 _maxLeverage,
+        uint256 fundingRateSensitivity
     ) public Ownable() {
         accountContract = IAccount(_accountContract);
         pricingContract = IPricing(_pricingContract);
@@ -88,6 +89,7 @@ contract Tracer is ITracer, SimpleDex, Ownable {
         priceMultiplier = 10**uint256(ioracle.decimals());
         feeRate = 0;
         maxLeverage = _maxLeverage;
+        FUNDING_RATE_SENSITIVITY = fundingRateSensitivity;
 
         // Start average prices from deployment
         startLastHour = block.timestamp;
@@ -448,6 +450,10 @@ contract Tracer is ITracer, SimpleDex, Ownable {
 
     function setMaxLeverage(int256 _maxLeverage) public override onlyOwner {
         maxLeverage = _maxLeverage;
+    }
+
+    function setFundingRateSensitivity(uint256 _fundingRateSensitivity) public override onlyOwner {
+        FUNDING_RATE_SENSITIVITY = _fundingRateSensitivity;
     }
 
     function transferOwnership(address newOwner) public override(Ownable, ITracer) onlyOwner {

--- a/migrations-ts/2_deploy_contracts.ts
+++ b/migrations-ts/2_deploy_contracts.ts
@@ -128,7 +128,7 @@ module.exports = async function (deployer, network, accounts) {
 
         //Deploy a new Tracer contract per test
         var deployTracerData = web3.eth.abi.encodeParameters(
-            ['bytes32', 'uint256', 'address', 'address', 'address', 'address', 'address', 'int256'],
+            ['bytes32', 'uint256', 'address', 'address', 'address', 'address', 'address', 'int256', 'uint256'],
             [
                 web3.utils.fromAscii(`TEST${i}/USD`),
                 750, //0.075 * 10000 (eg 7.5% scaled)
@@ -137,7 +137,8 @@ module.exports = async function (deployer, network, accounts) {
                 gasPriceOracle.address,
                 account.address,
                 pricing.address,
-                maxLeverage
+                maxLeverage,
+                1 //funding rate sensitivity
             ]
         )
         const proposeTracerData = web3.eth.abi.encodeFunctionCall(

--- a/migrations-ts/2_deploy_contracts.ts
+++ b/migrations-ts/2_deploy_contracts.ts
@@ -128,10 +128,9 @@ module.exports = async function (deployer, network, accounts) {
 
         //Deploy a new Tracer contract per test
         var deployTracerData = web3.eth.abi.encodeParameters(
-            ['bytes32', 'uint256', 'address', 'address', 'address', 'address', 'address', 'int256', 'uint256'],
+            ['bytes32', 'address', 'address', 'address', 'address', 'address', 'int256', 'uint256'],
             [
                 web3.utils.fromAscii(`TEST${i}/USD`),
-                750, //0.075 * 10000 (eg 7.5% scaled)
                 token.address,
                 oracle.address,
                 gasPriceOracle.address,

--- a/test-ts/functional/TracerFactory.ts
+++ b/test-ts/functional/TracerFactory.ts
@@ -45,10 +45,9 @@ describe("TracerFactory", async () => {
     context("Deploy and Approve", async () => {
         it.skip("approves the deployed market", async () => {
             let deployData = web3.eth.abi.encodeParameters(
-                ["bytes32", "uint256", "address", "address", "address", "address", "address", "int256"],
+                ["bytes32", "address", "address", "address", "address", "address", "int256"],
                 [
                     web3.utils.fromAscii(`LINK/USD`),
-                    750, //0.075 * 10000 (eg 7.5% scaled)
                     // govToken.address,
                     // oracle,
                     // gasPriceOracle,

--- a/test-ts/functional/TracerFactory.ts
+++ b/test-ts/functional/TracerFactory.ts
@@ -58,7 +58,8 @@ describe("TracerFactory", async () => {
                     accounts[0],
                     accounts[0],
                     //pricing,
-                    125000 //12.5 max leverage
+                    125000, //12.5 max leverage,
+                    1 //funding rate sensitivity
                 ]
             )
 

--- a/test-ts/lib/Setup.ts
+++ b/test-ts/lib/Setup.ts
@@ -270,10 +270,9 @@ export async function setupContractsAndTracer(accounts: Truffle.Accounts): Promi
 
     //Deploy a new Tracer contract per test
     var deployTracerData = web3.eth.abi.encodeParameters(
-        ["bytes32", "uint256", "address", "address", "address", "address", "address", "int256", "uint256"],
+        ["bytes32", "address", "address", "address", "address", "address", "int256", "uint256"],
         [
             web3.utils.fromAscii(`TEST/USD`),
-            750, //0.075 * 10000 (eg 7.5% scaled)
             testToken.address,
             oracle.address,
             gasPriceOracle.address,
@@ -405,10 +404,9 @@ export async function deployMultiTracers(
 
         //Deploy a new Tracer contract per test
         var deployTracerData = web3.eth.abi.encodeParameters(
-            ["bytes32", "uint256", "address", "address", "address", "address", "address", "uint256", "uint256"],
+            ["bytes32", "address", "address", "address", "address", "address", "uint256", "uint256"],
             [
                 web3.utils.fromAscii(`TEST${i}/USD`),
-                750, //0.075 * 10000 (eg 7.5% scaled)
                 token.address,
                 oracle.address,
                 gasPriceOracle.address,

--- a/test-ts/lib/Setup.ts
+++ b/test-ts/lib/Setup.ts
@@ -270,7 +270,7 @@ export async function setupContractsAndTracer(accounts: Truffle.Accounts): Promi
 
     //Deploy a new Tracer contract per test
     var deployTracerData = web3.eth.abi.encodeParameters(
-        ["bytes32", "uint256", "address", "address", "address", "address", "address", "int256"],
+        ["bytes32", "uint256", "address", "address", "address", "address", "address", "int256", "uint256"],
         [
             web3.utils.fromAscii(`TEST/USD`),
             750, //0.075 * 10000 (eg 7.5% scaled)
@@ -279,7 +279,8 @@ export async function setupContractsAndTracer(accounts: Truffle.Accounts): Promi
             gasPriceOracle.address,
             account.address,
             pricing.address,
-            maxLeverage
+            maxLeverage,
+            1 //funding rate sensitivity
         ]
     )
     const proposeTracerData = web3.eth.abi.encodeFunctionCall(
@@ -404,7 +405,7 @@ export async function deployMultiTracers(
 
         //Deploy a new Tracer contract per test
         var deployTracerData = web3.eth.abi.encodeParameters(
-            ["bytes32", "uint256", "address", "address", "address", "address", "address", "uint256"],
+            ["bytes32", "uint256", "address", "address", "address", "address", "address", "uint256", "uint256"],
             [
                 web3.utils.fromAscii(`TEST${i}/USD`),
                 750, //0.075 * 10000 (eg 7.5% scaled)
@@ -414,6 +415,7 @@ export async function deployMultiTracers(
                 account.address,
                 pricing.address,
                 maxLeverage,
+                1 //funding rate sensitivity
             ]
         )
         const proposeTracerData = web3.eth.abi.encodeFunctionCall(

--- a/test-ts/unit/Gov.ts
+++ b/test-ts/unit/Gov.ts
@@ -712,6 +712,7 @@ describe("Gov: unit tests", async () => {
                     account.address,
                     pricing.address,
                     oneDollar,
+                    1 //funding rate sensitivity
                 ]
             )
             const proposeTracerData = web3.eth.abi.encodeFunctionCall(

--- a/test-ts/unit/Gov.ts
+++ b/test-ts/unit/Gov.ts
@@ -702,10 +702,9 @@ describe("Gov: unit tests", async () => {
         /*
         it("executes external function calls", async () => {
             var deployTracerData = web3.eth.abi.encodeParameters(
-                ["bytes32", "uint256", "address", "address", "address", "address", "address", "uint256"],
+                ["bytes32", "address", "address", "address", "address", "address", "uint256"],
                 [
                     web3.utils.fromAscii(`TEST/USD`),
-                    750, //0.075 * 10000 (eg 7.5% scaled)
                     testToken.address,
                     oracle.address,
                     gasPriceOracle.address,


### PR DESCRIPTION
# Motivation
Previously the funding rate sensitivity was a constant 1 per market. This is now settable on deploy of the market, and also can be changed by the owner of a market at any point in time. This PR also removes the redundant `minMargin` param from deployment of markets.

# Changes
- remove `minMargin`
- add `fundingRateSensitivity` to deployment
- add a setter for funding rate sensitivity