### PR TITLE
Deploy insurance pool in TracerFactory.deployTracer

### DIFF
--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -737,7 +737,7 @@ contract Account is IAccount, Ownable {
      * @param market The Tracer market to check
      */
     modifier isValidTracer(address market) {
-        require(factory.validTracers(market), "ACT: Target not valid tracer");
+        // require(factory.validTracers(market) || true, "ACT: Target not valid tracer");
         _;
     }
 }

--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -737,7 +737,7 @@ contract Account is IAccount, Ownable {
      * @param market The Tracer market to check
      */
     modifier isValidTracer(address market) {
-        // require(factory.validTracers(market) || true, "ACT: Target not valid tracer");
+        require(factory.validTracers(market), "ACT: Target not valid tracer");
         _;
     }
 }

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./Interfaces/ITracer.sol";
 import "./Interfaces/IAccount.sol";
 import "./Interfaces/IInsurance.sol";
+import "./Interfaces/ITracerFactory.sol";
 import "./InsurancePoolToken.sol";
 import "./lib/LibMath.sol";
 
@@ -23,6 +24,7 @@ contract Insurance is IInsurance, Ownable {
     uint256 public constant SAFE_TOKEN_MULTIPLY = 1e18;
     address public immutable TCRTokenAddress;
     IAccount public account;
+    ITracerFactory public factory;
 
     struct StakePool { 
         address market;
@@ -190,8 +192,9 @@ contract Insurance is IInsurance, Ownable {
      *      this tracer to be supported
      * @param market the address of the new tracer market
      */
-    function deployInsurancePool(address market) external override onlyOwner() {
+    function deployInsurancePool(address market) external override {
         require(!supportedTracers[market], "INS: pool already exists");
+        require(factory.validTracers(market), "INS: pool not deployed by factory");
         ITracer _tracer = ITracer(market);
         // Deploy token for the pool
         InsurancePoolToken token = new InsurancePoolToken("Tracer Pool Token", "TPT", TCRTokenAddress);
@@ -298,10 +301,18 @@ contract Insurance is IInsurance, Ownable {
     }
 
     /**
+     * @notice sets the address of the Tracer factory
+     * @param tracerFactory the new address of the factory
+     */
+    function setFactory(address tracerFactory) external override onlyOwner {
+        factory = ITracerFactory(tracerFactory);
+    }
+
+    /**
      * @notice sets the address of the account contract (Account.sol)
      * @param accountContract the new address of the accountContract
      */
-    function setAccountContract(address accountContract) external onlyOwner {
+    function setAccountContract(address accountContract) external override onlyOwner {
         account = IAccount(accountContract);
     }
 

--- a/contracts/Interfaces/IInsurance.sol
+++ b/contracts/Interfaces/IInsurance.sol
@@ -31,6 +31,10 @@ interface IInsurance {
 
     function isInsured(address market) external view returns (bool);
 
+    function setFactory(address tracerFactory) external;
+
+    function setAccountContract(address accountContract) external;
+
     function INSURANCE_MUL_FACTOR() external view returns (int256);
     
 }

--- a/contracts/Receipt.sol
+++ b/contracts/Receipt.sol
@@ -93,7 +93,7 @@ contract Receipt is IReceipt, Ownable {
         require(block.timestamp < receipt.releaseTime, "REC: claim time passed");
         require(!receipt.liquidatorRefundClaimed, "REC: Already claimed");
         // Validate the escrowed order was fully sold
-        (uint256 unitsSold, int256 avgPrice) = calcUnitsSold(orderIds, escrowId, market, receipt.time);
+        (uint256 unitsSold, int256 avgPrice) = calcUnitsSold(orderIds, escrowId, market);
         require(
             unitsSold == uint256(receipt.amountLiquidated.abs()),
             "REC: Unit mismatch"
@@ -170,8 +170,7 @@ contract Receipt is IReceipt, Ownable {
     function calcUnitsSold(
         uint256[] memory orderIds,
         uint256 receiptId,
-        address market,
-        uint256 receiptStartTime
+        address market
     ) public view returns (uint256, int256) {
         Types.LiquidationReceipt memory receipt = liquidationReceipts[receiptId];
         uint256 unitsSold;

--- a/contracts/Tracer.sol
+++ b/contracts/Tracer.sol
@@ -286,7 +286,6 @@ contract Tracer is ITracer, SimpleDex, Ownable {
                 accountLastUpdatedIndex
             );
 
-            insuranceContract.INSURANCE_MUL_FACTOR();
             accountContract.settle(
                 account,
                 insuranceContract.INSURANCE_MUL_FACTOR(),

--- a/contracts/TracerFactory.sol
+++ b/contracts/TracerFactory.sol
@@ -67,9 +67,11 @@ contract TracerFactory is Ownable, ITracerFactory {
         // Create and link tracer to factory
         address market = IDeployer(deployer).deploy(_data);
         ITracer tracer = ITracer(market);
+
         validTracers[market] = true;
         tracersByIndex[tracerCounter] = market;
 
+        IInsurance(insurance).deployInsurancePool(market);
         tracerCounter++;
 
         // Perform admin operations on the tracer to finalise linking

--- a/migrations-ts/2_deploy_contracts.ts
+++ b/migrations-ts/2_deploy_contracts.ts
@@ -128,7 +128,7 @@ module.exports = async function (deployer, network, accounts) {
 
         //Deploy a new Tracer contract per test
         var deployTracerData = web3.eth.abi.encodeParameters(
-            ['bytes32', 'address', 'address', 'address', 'address', 'address', 'address', 'int256', 'uint256'],
+            ['bytes32', 'address', 'address', 'address', 'address', 'address', 'int256', 'uint256'],
             [
                 web3.utils.fromAscii(`TEST${i}/USD`),
                 token.address,
@@ -136,7 +136,6 @@ module.exports = async function (deployer, network, accounts) {
                 gasPriceOracle.address,
                 account.address,
                 pricing.address,
-                insurance.address,
                 maxLeverage,
                 1 //funding rate sensitivity
             ]

--- a/test-ts/functional/Insurance.ts
+++ b/test-ts/functional/Insurance.ts
@@ -166,15 +166,6 @@ describe("Insurance", async () => {
 
     })
 
-    context("Add Pool", async () => {
-        it("Only the owner can deploy a pool", async () => {
-            await expectRevert(
-                insurance.deployInsurancePool(tracers[0].address, { from: accounts[1] }),
-                "Ownable: caller is not the owner"
-            )
-        })
-    })
-
     context("Rewards", async () => {
         it("Allows rewards to be deposited to a pool and be claimed", async () => {
             //Stake

--- a/test-ts/functional/TracerFactory.ts
+++ b/test-ts/functional/TracerFactory.ts
@@ -1,7 +1,7 @@
 //@ts-ignore
 import { assert } from "chai"
-import { GovInstance, TracerFactoryInstance, AccountInstance, InsuranceInstance } from "../../types/truffle-contracts"
-import { setupFactoryFull, setupInsuranceFull, setupDeployer, setupGov, setupOracles, setupAccount } from "../lib/Setup"
+import { GovInstance, TracerFactoryInstance } from "../../types/truffle-contracts"
+import { setupFactoryFull } from "../lib/Setup"
 import { accounts, web3, configure } from "../configure"
 
 /**
@@ -12,7 +12,6 @@ describe("TracerFactory", async () => {
 
     let factory: TracerFactoryInstance
     let gov: GovInstance
-    let insurance: InsuranceInstance
     // let pricing: PricingInstance
     // let insurance: InsuranceInstance
     // let govToken: TestTokenInstance
@@ -26,15 +25,8 @@ describe("TracerFactory", async () => {
     beforeEach(async () => {
         //insurance, account, govToken
         let setupFactory = await setupFactoryFull(accounts)
-        let insuranceDeploy = await setupInsuranceFull(accounts)
         factory = setupFactory.factory
         gov = setupFactory.gov
-        insurance = insuranceDeploy.insurance
-
-
-        //oracles
-        let oracles = await setupOracles()
-
     })
 
     context("Initilization", async () => {
@@ -46,7 +38,7 @@ describe("TracerFactory", async () => {
     context("Deploy and Approve", async () => {
         it.skip("approves the deployed market", async () => {
             let deployData = web3.eth.abi.encodeParameters(
-                ["bytes32", "address", "address", "address", "address", "address", "address", "int256"],
+                ["bytes32", "address", "address", "address", "address", "address", "int256"],
                 [
                     web3.utils.fromAscii(`LINK/USD`),
                     // govToken.address,
@@ -57,7 +49,6 @@ describe("TracerFactory", async () => {
                     accounts[0],
                     accounts[0],
                     accounts[0],
-                    insurance.address,
                     //pricing,
                     125000, //12.5 max leverage,
                     1 //funding rate sensitivity

--- a/test-ts/functional/TracerFactory.ts
+++ b/test-ts/functional/TracerFactory.ts
@@ -1,9 +1,8 @@
 //@ts-ignore
 import { assert } from "chai"
-import { GovInstance, TracerFactoryInstance, AccountInstance, PricingInstance, InsuranceInstance, TestTokenInstance, OracleInstance, GasOracleInstance } from "../../types/truffle-contracts"
+import { GovInstance, TracerFactoryInstance, AccountInstance, InsuranceInstance } from "../../types/truffle-contracts"
 import { setupFactoryFull, setupInsuranceFull, setupDeployer, setupGov, setupOracles, setupAccount } from "../lib/Setup"
 import { accounts, web3, configure } from "../configure"
-import { TracerFactory } from "../artifacts"
 
 /**
  * Note: For all tests in this file, all admin functions are not called via the Governance system but
@@ -12,8 +11,8 @@ import { TracerFactory } from "../artifacts"
 describe("TracerFactory", async () => {
 
     let factory: TracerFactoryInstance
-    let account: AccountInstance
     let gov: GovInstance
+    let insurance: InsuranceInstance
     // let pricing: PricingInstance
     // let insurance: InsuranceInstance
     // let govToken: TestTokenInstance
@@ -27,8 +26,10 @@ describe("TracerFactory", async () => {
     beforeEach(async () => {
         //insurance, account, govToken
         let setupFactory = await setupFactoryFull(accounts)
+        let insuranceDeploy = await setupInsuranceFull(accounts)
         factory = setupFactory.factory
         gov = setupFactory.gov
+        insurance = insuranceDeploy.insurance
 
 
         //oracles
@@ -45,7 +46,7 @@ describe("TracerFactory", async () => {
     context("Deploy and Approve", async () => {
         it.skip("approves the deployed market", async () => {
             let deployData = web3.eth.abi.encodeParameters(
-                ["bytes32", "address", "address", "address", "address", "address", "int256"],
+                ["bytes32", "address", "address", "address", "address", "address", "address", "int256"],
                 [
                     web3.utils.fromAscii(`LINK/USD`),
                     // govToken.address,
@@ -56,6 +57,7 @@ describe("TracerFactory", async () => {
                     accounts[0],
                     accounts[0],
                     accounts[0],
+                    insurance.address,
                     //pricing,
                     125000, //12.5 max leverage,
                     1 //funding rate sensitivity

--- a/test-ts/unit/Insurance.ts
+++ b/test-ts/unit/Insurance.ts
@@ -13,7 +13,7 @@ import { accounts, web3, configure } from "../configure"
  * Note: For all tests in this file, all admin functions are not called via the Governance system but
  * simply by the owning account. For governance tests, see test/Gov.js
  */
-describe("Insurance", async () => {
+describe("Unit tests: Insurance", async () => {
     let insurance: InsuranceInstance
     let tracer: TracerInstance
     let testToken: TestTokenInstance


### PR DESCRIPTION
### Motivation

### Changes
#### Insurance.sol
- Removed `Insurance.deployInsurancePool`'s `onlyOwner` modifer. We want anyone to be able to deploy an insurance pool of a Tracer
- Added a check in `Insurance.deployInsurancePool` to make sure the market is a valid Tracer according to the factory.
    - For the above to work we need to be able to have a factory contract variable to check. This was added.
    - **This needs to be set after insurance contract is deployed**

#### Receipt.sol
- Unused variables

#### Tracer.sol
- Made `insuranceContract` a `IInsurance`, not just `address`.

#### TracerFactory.sol
- Calls `Insurance.deployInsurancePool` during `deployTracer`.

#### Migration script
- The insurance contract was already set in constructor, so doesn't need to be set again via proposal. This proposal was removed.