### PR TITLE
Alter off chain trade execution flow

### DIFF
--- a/contracts/DEX/SimpleDex.sol
+++ b/contracts/DEX/SimpleDex.sol
@@ -1,26 +1,27 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0 <0.7.0;
+pragma solidity >0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts/math/SignedSafeMath.sol";
-import "../lib/LibMath.sol";
-import "../Interfaces/Types.sol";
+import '@openzeppelin/contracts/math/SafeMath.sol';
+import '@openzeppelin/contracts/math/SignedSafeMath.sol';
+import '../lib/LibMath.sol';
+import '../Interfaces/Types.sol';
+import '../Interfaces/IDex.sol';
 
 /**
  * SimpleDex Contract: Implements the Tracer make/take without underlying
  * management checks.
  */
-contract SimpleDex {
+contract SimpleDex is IDex {
     using SafeMath for uint256;
     using SignedSafeMath for int256;
     using LibMath for uint256;
     using LibMath for int256;
 
-    //State variables
-    uint256 public orderCounter = 0;
+    // Order counter starts at 1 due to logic in Trader.sol
+    uint256 public orderCounter = 1;
     mapping(uint256 => Types.Order) public orders;
-
+    mapping(bytes32 => uint256) public override orderIdByHash;
 
     /**
      * @notice Places an on chain order via a permissioned contract, fillable by any part on chain.
@@ -38,7 +39,15 @@ contract SimpleDex {
         address maker
     ) internal returns (uint256) {
         //Create unfilled order
-        orders[orderCounter] = Types.Order(maker, amount, price, 0, side, expiration, block.timestamp);
+        Types.Order storage order = orders[orderCounter];
+        order.maker = maker;
+        order.amount = amount;
+        order.price = price;
+        order.side = side;
+        order.expiration = expiration;
+        order.creation = block.timestamp;
+        //Map order hash to id
+        orderIdByHash[hashOrder(amount, price, side, expiration, maker)] = orderCounter; 
         orderCounter++;
         return orderCounter - 1;
     }
@@ -54,12 +63,20 @@ contract SimpleDex {
         uint256 orderId,
         uint256 amount,
         address _taker
-    ) internal returns (Types.Order memory, uint256, uint256, address) {
+    )
+        internal
+        returns (
+            Types.Order memory,
+            uint256,
+            uint256,
+            address
+        )
+    {
         //Fill or partially fill order
         Types.Order storage order = orders[orderId];
-        require(order.amount.sub(order.filled) > 0, "SDX: Order filled");
+        require(order.amount.sub(order.filled) > 0, 'SDX: Order filled');
         /* solium-disable-next-line */
-        require(block.timestamp < order.expiration, "SDX: Order expired");
+        require(block.timestamp < order.expiration, 'SDX: Order expired');
 
         //Calculate the amount to fill
         uint256 fillAmount = (amount > order.amount.sub(order.filled)) ? order.amount.sub(order.filled) : amount;
@@ -70,5 +87,62 @@ contract SimpleDex {
 
         uint256 amountOutstanding = order.amount.sub(order.filled);
         return (order, fillAmount, amountOutstanding, order.maker);
+    }
+
+    /**
+    * @notice Matches two orders that have already both been made. Has the same
+    *         validation as takeOrder 
+    */
+    function _matchOrder(
+        uint256 order1Id,
+        uint256 order2Id
+    ) internal returns (uint256) {
+
+        // Fill or partially fill order
+        Types.Order storage order1 = orders[order1Id];
+        Types.Order storage order2 = orders[order2Id];
+
+        // Ensure orders can be cancelled against each other
+        require(order1.price == order2.price, 'SDX: price mismatch');
+        
+        /* solium-disable-next-line */
+        require(block.timestamp < order1.expiration &&
+            block.timestamp < order2.expiration, 'SDX: Order expired');
+
+        // Calculate the amount to fill
+        uint256 order1Remaining = order1.amount.sub(order1.filled);
+        uint256 order2Remaining = order2.amount.sub(order2.filled);
+        uint256 fillAmount = 0;
+        if (order1Remaining >= order2Remaining) {
+            // Use order2Remaining amount
+            fillAmount = order2Remaining;
+        } else {
+            // Use order1Remaining amount
+            fillAmount = order1Remaining;
+        }
+
+        //Update orders
+        order1.filled = order1.filled.add(fillAmount);
+        order2.filled = order2.filled.add(fillAmount);
+        order1.takers[order2.maker] = order1.takers[order2.maker].add(fillAmount);
+        order2.takers[order1.maker] = order2.takers[order1.maker].add(fillAmount);
+        return (fillAmount);
+    }
+
+    /**
+     * @notice hashes a limit order type in order to lookup via hash
+     * @return an simple hash of order data
+     */
+    function hashOrder(
+        uint256 amount,
+        int256 price,
+        bool side,
+        uint256 expiration,
+        address user
+    ) public view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(amount, price, side, user, expiration)
+            );
     }
 }

--- a/contracts/DEX/SimpleDex.sol
+++ b/contracts/DEX/SimpleDex.sol
@@ -106,7 +106,7 @@ contract SimpleDex is IDex {
         require(order1.price == order2.price, "SDX: Price mismatch");
 
         // Ensure orders are for opposite sides
-        require(order1.side != order2.side, "SDX: Side mismatch");
+        require(order1.side != order2.side, "SDX: Same side");
         
         /* solium-disable-next-line */
         require(block.timestamp < order1.expiration &&
@@ -115,7 +115,7 @@ contract SimpleDex is IDex {
         // Calculate the amount to fill
         uint256 order1Remaining = order1.amount.sub(order1.filled);
         uint256 order2Remaining = order2.amount.sub(order2.filled);
-        
+
         // fill amount is the minimum of order 1 and order 2
         uint256 fillAmount = order1Remaining > order2Remaining ? order2Remaining : order1Remaining;
 

--- a/contracts/DEX/SimpleDex.sol
+++ b/contracts/DEX/SimpleDex.sol
@@ -2,11 +2,11 @@
 pragma solidity >0.6.0;
 pragma experimental ABIEncoderV2;
 
-import '@openzeppelin/contracts/math/SafeMath.sol';
-import '@openzeppelin/contracts/math/SignedSafeMath.sol';
-import '../lib/LibMath.sol';
-import '../Interfaces/Types.sol';
-import '../Interfaces/IDex.sol';
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/SignedSafeMath.sol";
+import "../lib/LibMath.sol";
+import "../Interfaces/Types.sol";
+import "../Interfaces/IDex.sol";
 
 /**
  * SimpleDex Contract: Implements the Tracer make/take without underlying
@@ -74,9 +74,9 @@ contract SimpleDex is IDex {
     {
         //Fill or partially fill order
         Types.Order storage order = orders[orderId];
-        require(order.amount.sub(order.filled) > 0, 'SDX: Order filled');
+        require(order.amount.sub(order.filled) > 0, "SDX: Order filled");
         /* solium-disable-next-line */
-        require(block.timestamp < order.expiration, 'SDX: Order expired');
+        require(block.timestamp < order.expiration, "SDX: Order expired");
 
         //Calculate the amount to fill
         uint256 fillAmount = (amount > order.amount.sub(order.filled)) ? order.amount.sub(order.filled) : amount;
@@ -103,23 +103,21 @@ contract SimpleDex is IDex {
         Types.Order storage order2 = orders[order2Id];
 
         // Ensure orders can be cancelled against each other
-        require(order1.price == order2.price, 'SDX: price mismatch');
+        require(order1.price == order2.price, "SDX: Price mismatch");
+
+        // Ensure orders are for opposite sides
+        require(order1.side != order2.side, "SDX: Side mismatch");
         
         /* solium-disable-next-line */
         require(block.timestamp < order1.expiration &&
-            block.timestamp < order2.expiration, 'SDX: Order expired');
+            block.timestamp < order2.expiration, "SDX: Order expired");
 
         // Calculate the amount to fill
         uint256 order1Remaining = order1.amount.sub(order1.filled);
         uint256 order2Remaining = order2.amount.sub(order2.filled);
-        uint256 fillAmount = 0;
-        if (order1Remaining >= order2Remaining) {
-            // Use order2Remaining amount
-            fillAmount = order2Remaining;
-        } else {
-            // Use order1Remaining amount
-            fillAmount = order1Remaining;
-        }
+        
+        // fill amount is the minimum of order 1 and order 2
+        uint256 fillAmount = order1Remaining > order2Remaining ? order2Remaining : order1Remaining;
 
         //Update orders
         order1.filled = order1.filled.add(fillAmount);

--- a/contracts/Interfaces/IDex.sol
+++ b/contracts/Interfaces/IDex.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.6.0;
+import "./Types.sol";
+
+interface IDex {
+
+    function orderIdByHash(bytes32 orderHash) external returns (uint256);
+
+}

--- a/contracts/Interfaces/ITracer.sol
+++ b/contracts/Interfaces/ITracer.sol
@@ -80,4 +80,6 @@ interface ITracer {
     function transferOwnership(address newOwner) external;
 
     function initializePricing() external;
+
+    function matchOrders(uint order1, uint order2) external;
 }

--- a/contracts/Tracer.sol
+++ b/contracts/Tracer.sol
@@ -257,7 +257,7 @@ contract Tracer is ITracer, SimpleDex, Ownable {
     * @param order2 the second order that exists on chain
     */
     function matchOrders(uint order1, uint order2) public override {
-        // perform compatability checks (price, side) and calc fill amount
+        // perform compatibility checks (price, side) and calc fill amount
         uint256 fillAmount = _matchOrder(order1, order2);
 
         int256 orderPrice = orders[order1].price;

--- a/contracts/Tracer.sol
+++ b/contracts/Tracer.sol
@@ -251,6 +251,75 @@ contract Tracer is ITracer, SimpleDex, Ownable {
         );
     }
 
+     /**
+    * @notice Match two orders that exist against each other
+    * @param order1 the first order that exists on chain
+    * @param order2 the second order that exists on chain
+    */
+    function matchOrders(uint order1, uint order2) public override {
+        uint256 fillAmount = _matchOrder(order1, order2);
+
+        int256 orderPrice = orders[order1].price;
+        address order1User = orders[order1].maker;
+        address order2User = orders[order2].maker;
+        bool order1Side = orders[order1].side;
+        int256 baseChange = (fillAmount.mul(uint256(orderPrice))).div(priceMultiplier).toInt256();
+
+        //Update account states
+        //todo this is the same as takeOrder -> logic can be factored out
+        int256 neg1 = -1;
+
+        if (order1Side) {
+            // Maker long, taker short
+            // sub taker position, add taker margin, add maker position, sub taker margin
+            accountContract.updateAccountOnTrade(
+                baseChange,
+                neg1.mul(fillAmount.toInt256()),
+                order2User,
+                address(this)
+            );
+            accountContract.updateAccountOnTrade(
+                neg1.mul(baseChange),
+                fillAmount.toInt256(),
+                order1User,
+                address(this)
+            );
+        } else {
+            // Taker long, maker short
+            // add taker position, sub taker margin, sub maker position, add maker margin
+            accountContract.updateAccountOnTrade(
+                neg1.mul(baseChange),
+                fillAmount.toInt256(),
+                order1User,
+                address(this)
+            );
+            accountContract.updateAccountOnTrade(
+                baseChange,
+                neg1.mul(fillAmount.toInt256()),
+                order2User,
+                address(this)
+            );
+        }
+
+        // Update leverage
+        accountContract.updateAccountLeverage(order1User, address(this));
+        accountContract.updateAccountLeverage(order2User, address(this));
+
+        // Settle accounts
+        settle(order1User);
+        settle(order2User);
+
+        // Update internal trade state
+        updateInternalRecords(orderPrice);
+
+        // Ensures that you are in a position to take the trade
+        require(
+            accountContract.userMarginIsValid(order1User, address(this)) &&
+                accountContract.userMarginIsValid(order2User, address(this)),
+            "TCR: Margin Invalid post trade"
+        );
+    }
+
     /**
      * @notice settles an account. Compares current global rate with the users last updated rate
      *         Updates the accounts margin balance accordingly.

--- a/contracts/Tracer.sol
+++ b/contracts/Tracer.sol
@@ -257,6 +257,7 @@ contract Tracer is ITracer, SimpleDex, Ownable {
     * @param order2 the second order that exists on chain
     */
     function matchOrders(uint order1, uint order2) public override {
+        // perform compatability checks (price, side) and calc fill amount
         uint256 fillAmount = _matchOrder(order1, order2);
 
         int256 orderPrice = orders[order1].price;

--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -2,9 +2,9 @@
 pragma solidity >=0.6.0;
 pragma experimental ABIEncoderV2;
 
-import './Interfaces/ITracer.sol';
-import './Interfaces/IDex.sol';
-import './Interfaces/Types.sol';
+import "./Interfaces/ITracer.sol";
+import "./Interfaces/IDex.sol";
+import "./Interfaces/Types.sol";
 
 /**
  * The Trader contract is used to validate and execute off chain signed and matched orders
@@ -12,15 +12,15 @@ import './Interfaces/Types.sol';
 contract Trader {
     // EIP712 Constants
     // https://eips.ethereum.org/EIPS/eip-712
-    string private constant EIP712_DOMAIN_NAME = 'Tracer Protocol';
-    string private constant EIP712_DOMAIN_VERSION = '1.0';
+    string private constant EIP712_DOMAIN_NAME = "Tracer Protocol";
+    string private constant EIP712_DOMAIN_VERSION = "1.0";
     bytes32 private constant EIP712_DOMAIN_SEPERATOR =
-        keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)');
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
     // EIP712 Types
     bytes32 private constant LIMIT_ORDER_TYPE =
         keccak256(
-            'LimitOrder(uint256 amount,int256 price,bool side,address user,uint256 expiration,address targetTracer,uint256 nonce)'
+            "LimitOrder(uint256 amount,int256 price,bool side,address user,uint256 expiration,address targetTracer,uint256 nonce)"
         );
 
     uint256 constant chainId = 1337; // Changes per chain
@@ -56,12 +56,12 @@ contract Trader {
         Types.SignedLimitOrder[] memory takers,
         address market
     ) external {
-        require(makers.length == takers.length, 'TDR: Lengths differ');
+        require(makers.length == takers.length, "TDR: Lengths differ");
 
         // safe as we've already bounds checked the array lengths
         uint256 n = makers.length;
 
-        require(n > 0, 'TDR: Received empty arrays');
+        require(n > 0, "TDR: Received empty arrays");
 
         for (uint256 i = 0; i < n; i++) {
             // retrieve orders and verify their signatures
@@ -86,7 +86,7 @@ contract Trader {
         internal
         returns (uint256)
     {
-        require(index <= orders.length, 'TDR: Out of bounds access');
+        require(index <= orders.length, "TDR: Out of bounds access");
 
         IDex dex = IDex(market);
 
@@ -126,7 +126,7 @@ contract Trader {
         return
             keccak256(
                 abi.encodePacked(
-                    '\x19\x01',
+                    "\x19\x01",
                     EIP712_DOMAIN,
                     keccak256(
                         abi.encode(
@@ -181,8 +181,8 @@ contract Trader {
         bytes32 sigS,
         uint8 sigV
     ) public view returns (bool) {
-        require(verifySignature(signer, order, sigR, sigS, sigV), 'TDR: Signature verification failed');
-        require(verifyNonce(order), 'TDR: Incorrect nonce');
+        require(verifySignature(signer, order, sigR, sigS, sigV), "TDR: Signature verification failed");
+        require(verifyNonce(order), "TDR: Incorrect nonce");
         return true;
     }
 

--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -45,8 +45,7 @@ contract Trader {
 
     /**
      * @notice Batch executes maker and taker orders against a given market. Currently matching works
-     *         by fully matching a single take order with N make orders, and then moving to the next take
-     *         order.
+     *         by matching orders 1 to 1
      * @param makers An array of signed make orders
      * @param takers An array of signed take orders
      * @param market The market to execute the trade in
@@ -69,7 +68,7 @@ contract Trader {
             Types.LimitOrder memory currTaker = grabOrder(takers, i);
 
             /* check that prices match */
-            require(currMaker.price == currTaker.price, 'TDR: Encountered price mismatch');
+            require(currMaker.price == currTaker.price, 'TDR: Price mismatch');
 
             /* TODO: make order if it doesn't already exist on-chain */
         }

--- a/migrations-ts/2_deploy_contracts.ts
+++ b/migrations-ts/2_deploy_contracts.ts
@@ -205,15 +205,15 @@ module.exports = async function (deployer, network, accounts) {
         //Long order for 5 TEST/USD at a price of $1
         await tracer.makeOrder(web3.utils.toWei("5"), oneDollar, true, fourteenDays)
         //Short order for 5 TEST/USD against placed order
-        await tracer.takeOrder(0, web3.utils.toWei("5"), { from: accounts[1] })
+        await tracer.takeOrder(1, web3.utils.toWei("5"), { from: accounts[1] })
         //Long order for 2 TEST/USD at a price of $2
         await tracer.makeOrder(web3.utils.toWei("2"), new BN("200000000"), true, fourteenDays)
         //Short order for 2 TEST/USD against placed order
-        await tracer.takeOrder(1, web3.utils.toWei("2"), { from: accounts[1] })
+        await tracer.takeOrder(2, web3.utils.toWei("2"), { from: accounts[1] })
         //Long order for 1 TEST/USD at a price of $2
         await tracer.makeOrder(web3.utils.toWei("1"), new BN("300000000"), true, fourteenDays)
         //Short order for 1 TEST/USD against placed order
-        await tracer.takeOrder(2, web3.utils.toWei("1"), { from: accounts[1] })
+        await tracer.takeOrder(3, web3.utils.toWei("1"), { from: accounts[1] })
 
         //fast forward time
         await time.increase(time.duration.hours(1) + 600)
@@ -222,7 +222,7 @@ module.exports = async function (deployer, network, accounts) {
         //Long order for 1 TEST/USD at a price of $2
         await tracer.makeOrder(web3.utils.toWei("1"), new BN("300000000"), true, fourteenDays)
         //Short order for 1 TEST/USD against placed order
-        await tracer.takeOrder(3, web3.utils.toWei("1"), { from: accounts[1] })
+        await tracer.takeOrder(4, web3.utils.toWei("1"), { from: accounts[1] })
 
         //fast forward 24 hours and check fair price has now updated
         await time.increase(time.duration.hours(24))
@@ -230,7 +230,7 @@ module.exports = async function (deployer, network, accounts) {
         //Long order for 1 TEST/USD at a price of $1
         await tracer.makeOrder(web3.utils.toWei("1"), new BN("100000000"), true, fourteenDays)
         //Short order for 1 TEST/USD against placed order
-        await tracer.takeOrder(4, web3.utils.toWei("1"), { from: accounts[1] })
+        await tracer.takeOrder(5, web3.utils.toWei("1"), { from: accounts[1] })
 
         await oracle.setPrice(new BN("100000000"))
         //OR  Place long and short orders either side of $1

--- a/test-ts/functional/Insurance.ts
+++ b/test-ts/functional/Insurance.ts
@@ -366,7 +366,7 @@ describe("Insurance", async () => {
             await tracer.makeOrder(web3.utils.toWei("200"), newPrice, true, sevenDays, { from: accounts[2] })
             await tracer.takeOrder(4, web3.utils.toWei("200"), { from: accounts[3] })
             
-            await account.claimReceipts(0, [1, 2, 3], tracer.address, { from: accounts[2] })
+            await account.claimReceipts(0, [2, 3, 4], tracer.address, { from: accounts[2] })
             let insuranceBalance = await insurance.getPoolHoldings(tracer.address);
             assert.equal(insuranceBalance.toString(), web3.utils.toWei("1"))
         })

--- a/test-ts/functional/Insurance.ts
+++ b/test-ts/functional/Insurance.ts
@@ -269,7 +269,7 @@ describe("Insurance", async () => {
         //Leveraged notional value = $10
         await tracer.makeOrder(web3.utils.toWei("10000"), oneDollar, true, sevenDays)
         //Short order for 20 TEST/USD against placed order
-        await tracer.takeOrder(0, web3.utils.toWei("10000"), { from: accounts[1] })
+        await tracer.takeOrder(1, web3.utils.toWei("10000"), { from: accounts[1] })
 
         //Leveraged notional value = $180
         let lev = await tracer.leveragedNotionalValue()
@@ -301,14 +301,14 @@ describe("Insurance", async () => {
             //Long order for 5 TEST/USD at a price of $1
             await tracer.makeOrder(web3.utils.toWei("2000"), oneDollar, true, sevenDays)
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("2000"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("2000"), { from: accounts[1] })
             //Total Leveraged Value = $20
 
             //Time travel a day
             await time.increase(twentyFourHours)
             //Place order to trigger updates in contract pricing for the 24 hour period
             await tracer.makeOrder(web3.utils.toWei("1000"), oneDollar, true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(1, web3.utils.toWei("1000"), { from: accounts[3] })
+            await tracer.takeOrder(2, web3.utils.toWei("1000"), { from: accounts[3] })
             //Total leveraged value = $40
 
             //Funding rate should now be 0 as price is the same
@@ -338,7 +338,7 @@ describe("Insurance", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
             await oracle.setPrice(oneDollar);
 
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Price increases 95%, short order now is under margin requirements
             //$1 + 95% = 1.95
@@ -356,15 +356,15 @@ describe("Insurance", async () => {
 
             //Liquidator sells his positions across multiple orders, and as maker and taker
             await tracer.makeOrder(web3.utils.toWei("200"), newPrice, true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(1, web3.utils.toWei("200"), { from: accounts[3] })
+            await tracer.takeOrder(2, web3.utils.toWei("200"), { from: accounts[3] })
 
             await tracer.makeOrder(web3.utils.toWei("100"), newPrice, false, sevenDays, {
                 from: accounts[3],
             })
-            await tracer.takeOrder(2, web3.utils.toWei("100"), { from: accounts[2] })
+            await tracer.takeOrder(3, web3.utils.toWei("100"), { from: accounts[2] })
 
             await tracer.makeOrder(web3.utils.toWei("200"), newPrice, true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(3, web3.utils.toWei("200"), { from: accounts[3] })
+            await tracer.takeOrder(4, web3.utils.toWei("200"), { from: accounts[3] })
             
             await account.claimReceipts(0, [1, 2, 3], tracer.address, { from: accounts[2] })
             let insuranceBalance = await insurance.getPoolHoldings(tracer.address);

--- a/test-ts/functional/Tracer.ts
+++ b/test-ts/functional/Tracer.ts
@@ -213,7 +213,7 @@ describe("Tracer", async () => {
             assert.equal(account2[1].toString(), web3.utils.toWei("-500").toString())
 
             //Order takers state is updated
-            let orderTakerAmount = await tracer.getOrderTakerAmount(0, accounts[1])
+            let orderTakerAmount = await tracer.getOrderTakerAmount(1, accounts[1])
             assert.equal(orderTakerAmount.toString(), web3.utils.toWei("500").toString())
         })
 
@@ -246,7 +246,7 @@ describe("Tracer", async () => {
             assert.equal(account2[2].toString(), web3.utils.toWei("500").toString())
 
             //Order takers state is updated
-            let orderTakerAmount = await tracer.getOrderTakerAmount(0, accounts[1])
+            let orderTakerAmount = await tracer.getOrderTakerAmount(1, accounts[1])
             assert.equal(orderTakerAmount.toString(), web3.utils.toWei("1000").toString())
         })
 

--- a/test-ts/functional/Tracer.ts
+++ b/test-ts/functional/Tracer.ts
@@ -119,7 +119,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("1000"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order 5x leverage
-            await tracer.takeOrder(0, web3.utils.toWei("1000"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("1000"), { from: accounts[1] })
 
             //Current margin % = 1 - ((500 + gas cost (42.87)) / 1000)
             await expectRevert(
@@ -136,7 +136,7 @@ describe("Tracer", async () => {
             const tx = await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
             await expectEvent(tx.receipt, "OrderMade", {
                 //DEPRECATED: tracerId: web3.utils.padRight(web3.utils.asciiToHex("TEST/USD"), 64),
-                orderId: new BN("0"),
+                orderId: new BN("1"),
                 amount: web3.utils.toWei("500").toString(),
                 price: oneDollar,
                 maker: accounts[0],
@@ -144,7 +144,7 @@ describe("Tracer", async () => {
             })
 
             //amount, filled, price, side
-            let order = await tracer.getOrder(0)
+            let order = await tracer.getOrder(1)
             assert.equal(order[0].toString(), web3.utils.toWei("500").toString())
             assert.equal(order[1].toString(), web3.utils.toWei("0").toString())
             assert.equal(order[2].toString(), oneDollar.toString())
@@ -158,7 +158,7 @@ describe("Tracer", async () => {
 
             await expectEvent(tx.receipt, "OrderMade", {
                 //DEPRECATED: tracerId: web3.utils.padRight(web3.utils.asciiToHex("TEST/USD"), 64),
-                orderId: new BN("0"),
+                orderId: new BN("1"),
                 amount: web3.utils.toWei("4000").toString(),
                 price: oneDollar,
                 maker: accounts[0],
@@ -166,7 +166,7 @@ describe("Tracer", async () => {
             })
 
             //amount, filled, price, side
-            let order = await tracer.getOrder(0)
+            let order = await tracer.getOrder(1)
             assert.equal(order[0].toString(), web3.utils.toWei("4000").toString())
             assert.equal(order[1].toString(), web3.utils.toWei("0").toString())
             assert.equal(order[2].toString(), oneDollar.toString())
@@ -194,10 +194,10 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //assert amount, filled
-            let order = await tracer.getOrder(0)
+            let order = await tracer.getOrder(1)
             assert.equal(order[0].toString(), web3.utils.toWei("500").toString())
             assert.equal(order[1].toString(), web3.utils.toWei("500").toString())
 
@@ -225,10 +225,10 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("1000"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("1000"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("1000"), { from: accounts[1] })
 
             //assert amount, filled
-            let order = await tracer.getOrder(0)
+            let order = await tracer.getOrder(1)
             assert.equal(order[0].toString(), web3.utils.toWei("1000").toString())
             assert.equal(order[1].toString(), web3.utils.toWei("1000").toString())
 
@@ -258,12 +258,12 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Short order for 3 TEST/USD against placed order
             await expectRevert(
                 //Order over 10x leverage
-                tracer.takeOrder(0, web3.utils.toWei("3"), { from: accounts[2] }),
+                tracer.takeOrder(2, web3.utils.toWei("3"), { from: accounts[2] }),
                 "SDX: Order filled"
             )
         })
@@ -277,13 +277,13 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 3 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("30"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("30"), { from: accounts[1] })
 
             //Short order for 3 TEST/USD against placed order, only fills 2
-            await tracer.takeOrder(0, web3.utils.toWei("30"), { from: accounts[2] })
+            await tracer.takeOrder(1, web3.utils.toWei("30"), { from: accounts[2] })
 
             //assert amount, filled
-            let order = await tracer.getOrder(0)
+            let order = await tracer.getOrder(1)
             assert.equal(order[0].toString(), web3.utils.toWei("500").toString())
             assert.equal(order[1].toString(), web3.utils.toWei("60").toString())
 
@@ -314,7 +314,7 @@ describe("Tracer", async () => {
             await expectRevert(
                 //Order over 10x leverage
 
-                tracer.takeOrder(0, web3.utils.toWei("3"), { from: accounts[2] }),
+                tracer.takeOrder(1, web3.utils.toWei("3"), { from: accounts[2] }),
                 "SDX: Order expired"
             )
         })
@@ -331,7 +331,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Price increases 80%, short order now is under margin requirements
             //$1 + 80% = 1.80
@@ -366,7 +366,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Price increases 60%, short order now is under margin requirements
             //$1 + 60% = 1.60
@@ -400,7 +400,7 @@ describe("Tracer", async () => {
             //Long order for 5 TEST/USD at a price of $1
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("5"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("5"), { from: accounts[1] })
 
             //Price increases 10%, both accounts still in margin
             //$1 + 10% = 1.1
@@ -421,7 +421,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Price increases 58%, short order now is under margin requirements
             //$1 + 58% = 1.58
@@ -451,7 +451,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Price increases 60%, short order now is under margin requirements
             //$1 + 60% = 1.60
@@ -492,7 +492,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Price increases 60%, short order now is under margin requirements
             //$1 + 60% = 1.60
@@ -511,15 +511,15 @@ describe("Tracer", async () => {
 
             //Liquidator sells his positions across multiple orders, and as maker and taker
             await tracer.makeOrder(web3.utils.toWei("200"), lowerPrice, true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(1, web3.utils.toWei("200"), { from: accounts[3] })
+            await tracer.takeOrder(2, web3.utils.toWei("200"), { from: accounts[3] })
 
             await tracer.makeOrder(web3.utils.toWei("100"), lowerPrice, false, sevenDays, {
                 from: accounts[3],
             })
-            await tracer.takeOrder(2, web3.utils.toWei("100"), { from: accounts[2] })
+            await tracer.takeOrder(3, web3.utils.toWei("100"), { from: accounts[2] })
 
             await tracer.makeOrder(web3.utils.toWei("200"), lowerPrice, true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(3, web3.utils.toWei("200"), { from: accounts[3] })
+            await tracer.takeOrder(4, web3.utils.toWei("200"), { from: accounts[3] })
 
             // Liquidated at $1.6, sold at $1.61.
             // 1.61*500 - 1.6 * 500 = $5
@@ -527,7 +527,7 @@ describe("Tracer", async () => {
             let balanceBefore = await account.getBalance(accounts[2], tracer.address)
             let traderBalanceBefore = await account.getBalance(accounts[1], tracer.address)
 
-            await account.claimReceipts(0, [1, 2, 3], tracer.address, { from: accounts[2] })
+            await account.claimReceipts(0, [2, 3, 4], tracer.address, { from: accounts[2] })
 
             let balanceAfter = await account.getBalance(accounts[2], tracer.address)
             let traderBalanceAfter = await account.getBalance(accounts[1], tracer.address)
@@ -566,7 +566,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Price increases 60%, short order now is under margin requirements
             //$1 + 60% = 1.60
@@ -587,15 +587,15 @@ describe("Tracer", async () => {
 
             //Liquidator sells his positions across multiple orders, and as maker and taker
             await tracer.makeOrder(web3.utils.toWei("200"), lowerPrice, true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(1, web3.utils.toWei("200"), { from: accounts[3] })
+            await tracer.takeOrder(2, web3.utils.toWei("200"), { from: accounts[3] })
 
             await tracer.makeOrder(web3.utils.toWei("100"), lowerPrice, false, sevenDays, {
                 from: accounts[3],
             })
-            await tracer.takeOrder(2, web3.utils.toWei("100"), { from: accounts[2] })
+            await tracer.takeOrder(3, web3.utils.toWei("100"), { from: accounts[2] })
 
             await tracer.makeOrder(web3.utils.toWei("200"), lowerPrice, true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(3, web3.utils.toWei("200"), { from: accounts[3] })
+            await tracer.takeOrder(4, web3.utils.toWei("200"), { from: accounts[3] })
 
             // Liquidated at $1.6, sold at $1.62.
             // 1.62*500 - 1.6 * 500 = $10
@@ -604,7 +604,7 @@ describe("Tracer", async () => {
             let balanceBefore = await account.getBalance(accounts[2], tracer.address)
             let traderBalanceBefore = await account.getBalance(accounts[1], tracer.address)
 
-            await account.claimReceipts(0, [1, 2, 3], tracer.address, { from: accounts[2] })
+            await account.claimReceipts(0, [2, 3, 4], tracer.address, { from: accounts[2] })
 
             let balanceAfter = await account.getBalance(accounts[2], tracer.address)
             let traderBalanceAfter = await account.getBalance(accounts[1], tracer.address)
@@ -638,7 +638,7 @@ describe("Tracer", async () => {
         it("Liquidator can not claim escrowed funds with orders that are too old", async () => {
             await account.deposit(web3.utils.toWei("500"), tracer.address)
             await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[1] })
-            let currentOrderId = 0;
+            let currentOrderId = 1;
             const oneSixtyOne = new BN("161000000")
             const oneSixty = new BN("160000000")
 
@@ -701,7 +701,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("750"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("750"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("750"), { from: accounts[1] })
 
             //Check margin of account
             //margin = 1 - ((margin + liquidation gas) / position value)
@@ -724,7 +724,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //Check margin of leveraged account (SHORT)
             //margin is ((600 - 42.87) / 500) - 1
@@ -749,7 +749,7 @@ describe("Tracer", async () => {
             await tracer.makeOrder(web3.utils.toWei("500"), oneDollar, true, sevenDays)
 
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("500"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("500"), { from: accounts[1] })
 
             //50% price increase to $1.5
             await oracle.setPrice(new BN("150000000"))
@@ -775,14 +775,14 @@ describe("Tracer", async () => {
             //Long order for 5 TEST/USD at a price of $1.01
             await tracer.makeOrder(web3.utils.toWei("505"), new BN("101000000"), true, sevenDays)
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("505"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("505"), { from: accounts[1] })
 
             //Time travel a day
             await time.increase(twentyFourHours)
 
             // Place order to trigger updates in contract pricing for the 24 hour period
             await tracer.makeOrder(web3.utils.toWei("505"), new BN("101000000"), true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(1, web3.utils.toWei("505"), { from: accounts[3] })
+            await tracer.takeOrder(2, web3.utils.toWei("505"), { from: accounts[3] })
 
             //Check 24 hour prices
             let currentHour = (await tracer.currentHour()).toNumber()
@@ -825,14 +825,14 @@ describe("Tracer", async () => {
             //Long order
             await tracer.makeOrder(web3.utils.toWei("2000"), oneDollar, true, sevenDays)
             //Short order
-            await tracer.takeOrder(0, web3.utils.toWei("2000"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("2000"), { from: accounts[1] })
             //Total Leveraged Value = $2000
 
             //Time travel a day
             await time.increase(twentyFourHours)
             //Place order to trigger updates in contract pricing for the 24 hour period
             await tracer.makeOrder(web3.utils.toWei("1000"), oneDollar, true, sevenDays, { from: accounts[2] })
-            await tracer.takeOrder(1, web3.utils.toWei("1000"), { from: accounts[3] })
+            await tracer.takeOrder(2, web3.utils.toWei("1000"), { from: accounts[3] })
             //Total leveraged value = $4000
 
             //Funding rate should now be 0 as price is the same
@@ -877,7 +877,7 @@ describe("Tracer", async () => {
             )
             await expectEvent(tx.receipt, "OrderMade", {
                 //DEPRECATED: tracerId: web3.utils.padRight(web3.utils.asciiToHex("TEST/USD"), 64),
-                orderId: new BN("0"),
+                orderId: new BN("1"),
                 amount: web3.utils.toWei("5").toString(),
                 price: oneDollar,
                 maker: accounts[0],
@@ -885,7 +885,7 @@ describe("Tracer", async () => {
             })
 
             //amount, filled, price, side
-            let order = await tracer.getOrder(0)
+            let order = await tracer.getOrder(1)
             assert.equal(order[0].toString(), web3.utils.toWei("5").toString())
             assert.equal(order[1].toString(), web3.utils.toWei("0").toString())
             assert.equal(order[2].toString(), oneDollar.toString())
@@ -913,16 +913,16 @@ describe("Tracer", async () => {
             //Long order for 5 TEST/USD at a price of $1
             await tracer.makeOrder(web3.utils.toWei("5"), oneDollar, true, sevenDays)
             //Short order for 5 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("5"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("5"), { from: accounts[1] })
             //Long order for 2 TEST/USD at a price of $2
             await tracer.makeOrder(web3.utils.toWei("2"), new BN("200000000"), true, sevenDays)
             //Short order for 2 TEST/USD against placed order
-            await tracer.takeOrder(1, web3.utils.toWei("2"), { from: accounts[1] })
+            await tracer.takeOrder(2, web3.utils.toWei("2"), { from: accounts[1] })
             //Long order for 1 TEST/USD at a price of $2
             await tracer.makeOrder(web3.utils.toWei("1"), new BN("300000000"), true, sevenDays)
             //Short order for 1 TEST/USD against placed order
             
-            await tracer.takeOrder(2, web3.utils.toWei("1"), { from: accounts[1] })
+            await tracer.takeOrder(3, web3.utils.toWei("1"), { from: accounts[1] })
 
             //fast forward time
             await time.increase(oneHour + 600)
@@ -931,7 +931,7 @@ describe("Tracer", async () => {
             //Long order for 1 TEST/USD at a price of $2
             await tracer.makeOrder(web3.utils.toWei("1"), new BN("300000000"), true, sevenDays)
             //Short order for 1 TEST/USD against placed order
-            await tracer.takeOrder(3, web3.utils.toWei("1"), { from: accounts[1] })
+            await tracer.takeOrder(4, web3.utils.toWei("1"), { from: accounts[1] })
 
             //Average price over last hour = 1+2+3/3 = 2
             //average oracle price over last hour = 200000000
@@ -953,7 +953,7 @@ describe("Tracer", async () => {
             //Long order for 1 TEST/USD at a price of $1
             await tracer.makeOrder(web3.utils.toWei("1"), new BN("100000000"), true, sevenDays)
             //Short order for 1 TEST/USD against placed order
-            await tracer.takeOrder(4, web3.utils.toWei("1"), { from: accounts[1] })
+            await tracer.takeOrder(5, web3.utils.toWei("1"), { from: accounts[1] })
             let fairPriceUpdated = await pricing.fairPrices(tracer.address)
             let avgPricesUpdated = await pricing.get24HourPrices(tracer.address)
             //fair price = oracle price - time value = $1 - (avg derivative price - average oracle price)/90
@@ -976,7 +976,7 @@ describe("Tracer", async () => {
             //Leveraged notional value = $1000
             await tracer.makeOrder(web3.utils.toWei("2000"), oneDollar, true, sevenDays)
             //Short order for 2000 TEST/USD against placed order
-            await tracer.takeOrder(0, web3.utils.toWei("2000"), { from: accounts[1] })
+            await tracer.takeOrder(1, web3.utils.toWei("2000"), { from: accounts[1] })
 
             //Leveraged notional value = $1000
             let userBalance = await account.getBalance(accounts[0], tracer.address)
@@ -993,7 +993,7 @@ describe("Tracer", async () => {
             //user deposited in 1000 so is borrowing 1200 to get to a notional value of $1200
             await tracer.makeOrder(web3.utils.toWei("200"), oneDollar, true, sevenDays)
             //Short order for 200 TEST/USD against placed order
-            await tracer.takeOrder(1, web3.utils.toWei("200"), { from: accounts[2] })
+            await tracer.takeOrder(2, web3.utils.toWei("200"), { from: accounts[2] })
             //Leveraged notional value = $1000 + $200
             let updatedLev = await tracer.leveragedNotionalValue()
             assert.equal(updatedLev.toString(), web3.utils.toWei("1200"))
@@ -1001,7 +1001,7 @@ describe("Tracer", async () => {
             //Account 1 goes further short to increase leverage
             //leverage increased by $300
             await tracer.makeOrder(web3.utils.toWei("300"), oneDollar, false, sevenDays, { from: accounts[1] })
-            await tracer.takeOrder(2, web3.utils.toWei("300"), { from: accounts[2] })
+            await tracer.takeOrder(3, web3.utils.toWei("300"), { from: accounts[2] })
 
             //Account 1 has deposited $2000 and now has 2300 short positions worth $2300
             //total Leveraged notional value = $1200 + $300 = accounts[0].leveragedNotionalValue + accounts[1].leveragedNotionalValue
@@ -1010,7 +1010,7 @@ describe("Tracer", async () => {
 
             //Account 0 sells off all of their long, reducing system leverage
             await tracer.makeOrder(web3.utils.toWei("1200"), oneDollar, true, sevenDays, { from: accounts[3] })
-            await tracer.takeOrder(3, web3.utils.toWei("1200"), { from: accounts[0] })
+            await tracer.takeOrder(4, web3.utils.toWei("1200"), { from: accounts[0] })
 
             //total Leveraged notional value = $15 - $12
             let updatedLev3 = await tracer.leveragedNotionalValue()

--- a/test-ts/functional/Trader.ts
+++ b/test-ts/functional/Trader.ts
@@ -107,7 +107,7 @@ describe("Trader", async () => {
 
             //Check post trade positions
             //assert amount, filled
-            let order = await tracer.getOrder(0)
+            let order = await tracer.getOrder(1)
             assert.equal(order[0].toString(), web3.utils.toWei("500").toString())
             assert.equal(order[1].toString(), web3.utils.toWei("500").toString())
 
@@ -179,7 +179,7 @@ describe("Trader", async () => {
 
             await expectRevert(
                 trader.executeTrade(signedMakes, signedTakes, tracer.address),
-                "TDR: incorrect order sig or nonce"
+                "TDR: Incorrect nonce"
             )
         })
 
@@ -242,7 +242,7 @@ describe("Trader", async () => {
 
                 await expectRevert(
                     trader.executeTrade(signedMakes2, signedTakesReplay, tracer.address),
-                    "TDR: incorrect order sig or nonce"
+                    "TDR: Incorrect nonce"
                 )
         })
     })

--- a/test-ts/functional/Trader.ts
+++ b/test-ts/functional/Trader.ts
@@ -5,65 +5,10 @@ import { AccountInstance, DeployerV1Instance, GasOracleInstance, GovInstance, In
 import { Trader } from "../artifacts"
 import { setupContractsAndTracer } from "../lib/Setup"
 import { accounts, web3, configure } from "../configure"
-
+import { signOrders } from "../lib/Signing"
 
 require("dotenv").config()
 
-//Signing Helper Function
-//@ts-ignore
-const signOrder = async (web3, signingAccount, data, callback) => {
-    const signer = web3.utils.toChecksumAddress(signingAccount)
-    return new Promise((resolve, reject) => {
-        web3.currentProvider.send(
-            {
-                method: "eth_signTypedData",
-                params: [signer, data],
-                from: signer,
-            },
-            //@ts-ignore
-            async (err, result) => {
-                if (err) {
-                    reject(err)
-                }
-                let parsedSig = result.result.substring(2)
-                const r = "0x" + parsedSig.substring(0, 64)
-                const s = "0x" + parsedSig.substring(64, 128)
-                const v = parseInt(parsedSig.substring(128, 130), 16) //130 hex = 65bytes
-                return resolve([r, s, v])
-            }
-        )
-    })
-}
-
-
-//Process and sign orders
-//@ts-ignore
-const signOrders = async (orders, domain, domainData, limitOrder) => {
-    //@ts-ignore
-    return orders.map(async (order) => {
-        let type = {
-            EIP712Domain: domain,
-            LimitOrder: limitOrder,
-        }
-
-        let dataToSign = {
-            domain: domainData,
-            primaryType: "LimitOrder",
-            message: order,
-            types: type,
-        }
-
-        //@ts-ignore
-        let signedData: [string, string, string] = await signOrder(web3, order.user, dataToSign)
-
-        return {
-            order: order,
-            sigR: signedData[0],
-            sigS: signedData[1],
-            sigV: signedData[2],
-        }
-    })
-}
 
 const threeDays = 259200
 const twoDays = 172800
@@ -124,42 +69,6 @@ describe("Trader", async () => {
             await tracer.setUserPermissions(trader.address, true, { from: accounts[i] })
         }
 
-        //Signed Order Helpers
-        domain = [
-            { name: "name", type: "string" },
-            { name: "version", type: "string" },
-            { name: "chainId", type: "uint256" },
-            { name: "verifyingContract", type: "address" },
-            // { name: "salt", type: "bytes32" },
-        ]
-
-        limitOrder = [
-            { name: "amount", type: "uint256" },
-            { name: "price", type: "int256" },
-            { name: "side", type: "bool" },
-            { name: "user", type: "address" },
-            { name: "expiration", type: "uint256" },
-            { name: "targetTracer", type: "address" },
-            { name: "nonce", type: "uint256" },
-        ]
-
-        domainData = {
-            name: "Tracer Protocol",
-            version: "1.0",
-            chainId: 1337,
-            verifyingContract: trader.address,
-            //salt: web3.utils.keccak256("Go Long Yourself"),
-        }
-        let sampleOrder = {
-            amount: "5000000000000000000",
-            price: "100000000",
-            side: true,
-            user: "0x392D3d2313E71aF6B5E7DA923aB01919F7393997",
-            expiration: 1598590237,
-            targetTracer: "0xC921f73263d751774603e7a2bB5f9c989eb349dE",
-            nonce: 18,
-        }
-
         now = await time.latest()
         sevenDays = parseInt(now) + 604800 //7 days from now
     })
@@ -190,8 +99,8 @@ describe("Trader", async () => {
                 }
             ]
 
-            let signedTakes: any = await Promise.all(await signOrders(takes, domain, domainData, limitOrder))
-            let signedMakes: any = await Promise.all(await signOrders(makes, domain, domainData, limitOrder))
+            let signedTakes: any = await Promise.all(await signOrders(web3, takes, trader.address))
+            let signedMakes: any = await Promise.all(await signOrders(web3, makes, trader.address))
 
             await account.deposit(web3.utils.toWei("500"), tracer.address)
             await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[1] })
@@ -217,11 +126,67 @@ describe("Trader", async () => {
             assert.equal(account2[1].toString(), web3.utils.toWei("-500").toString())
         })
 
-        //TODO: Fix once we've had a chat about order matching on chain
-        //the OME needs to be able to send an order that already been created
-        //and the trader contract should not make a new order for it.
-        it.skip("Can batch execute trades (complex)", async () => {
-            //Build some make and take orders
+
+        it("Detects replay attacks in the same batch", async () => {
+            let makes = [
+                {
+                    amount: web3.utils.toWei("200"),
+                    price: oneDollar.toString(),
+                    side: true,
+                    user: accounts[0],
+                    expiration: sevenDays,
+                    targetTracer: tracer.address,
+                    nonce: 0,
+                },
+                {
+                    amount: web3.utils.toWei("200"),
+                    price: oneDollar.toString(),
+                    side: true,
+                    user: accounts[0],
+                    expiration: sevenDays,
+                    targetTracer: tracer.address,
+                    nonce: 1,
+                },
+            ]
+            let takes = [
+                {
+                    amount: web3.utils.toWei("200"),
+                    price: oneDollar.toString(),
+                    side: false,
+                    user: accounts[1],
+                    expiration: sevenDays,
+                    targetTracer: tracer.address,
+                    nonce: 0,
+                },
+            ]
+
+            let takesReplay = [
+                {
+                    amount: web3.utils.toWei("200"),
+                    price: oneDollar.toString(),
+                    side: false,
+                    user: accounts[1],
+                    expiration: sevenDays,
+                    targetTracer: tracer.address,
+                    nonce: 0,
+                },
+            ]
+
+            let signedTakesNormal: any = await Promise.all(await signOrders(web3, takes, trader.address))
+            let signedTakesReplay: any = await Promise.all(await signOrders(web3, takesReplay, trader.address))
+            let signedMakes: any = await Promise.all(await signOrders(web3, makes, trader.address))
+            let signedTakes: any = signedTakesNormal.concat(signedTakesReplay)
+
+            await account.deposit(web3.utils.toWei("500"), tracer.address)
+            await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[1] })
+
+            await expectRevert(
+                trader.executeTrade(signedMakes, signedTakes, tracer.address),
+                "TDR: incorrect order sig or nonce"
+            )
+        })
+
+        it("Detects replay attacks in the different batches", async () => {
             let makes = [
                 {
                     amount: web3.utils.toWei("500"),
@@ -232,310 +197,60 @@ describe("Trader", async () => {
                     targetTracer: tracer.address,
                     nonce: 0,
                 },
-                {
-                    amount: web3.utils.toWei("500"),
-                    price: oneDollar.toString(),
-                    side: true,
-                    user: accounts[0],
-                    expiration: sevenDays,
-                    targetTracer: tracer.address,
-                    nonce: 0,
-                },
-                {
-                    amount: web3.utils.toWei("500"),
-                    price: oneDollar.toString(),
-                    side: true,
-                    user: accounts[1],
-                    expiration: sevenDays,
-                    targetTracer: tracer.address,
-                    nonce: 1,
-                },
             ]
             let takes = [
-                {
-                    amount: web3.utils.toWei("300"),
-                    price: oneDollar.toString(),
-                    side: false,
-                    user: accounts[1],
-                    expiration: sevenDays,
-                    targetTracer: tracer.address,
-                    nonce: 0,
-                },
                 {
                     amount: web3.utils.toWei("200"),
                     price: oneDollar.toString(),
                     side: false,
-                    user: accounts[2],
-                    expiration: sevenDays,
-                    targetTracer: tracer.address,
-                    nonce: 0,
-                },
-                {
-                    amount: web3.utils.toWei("100"),
-                    price: oneDollar.toString(),
-                    side: false,
-                    user: accounts[0],
-                    expiration: sevenDays,
-                    targetTracer: tracer.address,
-                    nonce: 1,
-                },
-                {
-                    amount: web3.utils.toWei("100"),
-                    price: oneDollar.toString(),
-                    side: false,
-                    user: accounts[2],
-                    expiration: sevenDays,
-                    targetTracer: tracer.address,
-                    nonce: 1,
-                },
-                {
-                    amount: web3.utils.toWei("100"),
-                    price: oneDollar.toString(),
-                    side: false,
-                    user: accounts[3],
+                    user: accounts[1],
                     expiration: sevenDays,
                     targetTracer: tracer.address,
                     nonce: 0,
                 },
             ]
 
-            let signedTakes: any = await Promise.all(await signOrders(takes, domain, domainData, limitOrder))
-            let signedMakes: any = await Promise.all(await signOrders(makes, domain, domainData, limitOrder))
+            let makes2 = [
+                {
+                    amount: web3.utils.toWei("500"),
+                    price: oneDollar.toString(),
+                    side: true,
+                    user: accounts[0],
+                    expiration: sevenDays,
+                    targetTracer: tracer.address,
+                    nonce: 1,
+                },
+            ]
 
+            let takesReplay = [
+                {
+                    amount: web3.utils.toWei("200"),
+                    price: oneDollar.toString(),
+                    side: false,
+                    user: accounts[1],
+                    expiration: sevenDays,
+                    targetTracer: tracer.address,
+                    nonce: 0,
+                },
+            ]
+
+            let signedTakesNormal: any = await Promise.all(await signOrders(web3, takes, trader.address))
+            let signedTakesReplay: any = await Promise.all(await signOrders(web3, takes, trader.address))
+            let signedMakes: any = await Promise.all(await signOrders(web3, makes, trader.address))
+            let signedMakes2: any = await Promise.all(await signOrders(web3, makes2, trader.address))
             await account.deposit(web3.utils.toWei("500"), tracer.address)
             await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[1] })
-            await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[2] })
-            await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[3] })
 
-            let batchTxn = await trader.executeTrade(signedMakes, signedTakes, tracer.address)
+            await trader.executeTrade(signedMakes, signedTakesNormal, tracer.address),
 
-            //Check positions are updated
-            let account1 = await account.getBalance(accounts[0], tracer.address)
-            let account2 = await account.getBalance(accounts[1], tracer.address)
-            let account3 = await account.getBalance(accounts[2], tracer.address)
-            let account4 = await account.getBalance(accounts[3], tracer.address)
-
-            //Account 1 margin and position (MAKER)
-            //LONG 5, SHORT 1
-            assert.equal(account1[0].toString(), web3.utils.toWei("100").toString())
-            assert.equal(account1[1].toString(), web3.utils.toWei("400").toString())
-            //Account 2 margin and position
-            //LONG 5, SHORT 3, only 3 of long filled
-            assert.equal(account2[0].toString(), web3.utils.toWei("500").toString())
-            assert.equal(account2[1].toString(), web3.utils.toWei("0").toString())
-            //Account 3 margin and position
-            //SHORT 3
-            assert.equal(account3[0].toString(), web3.utils.toWei("800").toString())
-            assert.equal(account3[1].toString(), web3.utils.toWei("-300").toString())
-            //Account 4 margin and position
-            //SHORT 1
-            assert.equal(account4[0].toString(), web3.utils.toWei("600").toString())
-            assert.equal(account4[1].toString(), web3.utils.toWei("-100").toString())
+                await expectRevert(
+                    trader.executeTrade(signedMakes2, signedTakesReplay, tracer.address),
+                    "TDR: incorrect order sig or nonce"
+                )
         })
     })
 
-    it("Validation of Signed Orders", async () => {
-        const makeOrder = {
-            amount: web3.utils.toWei("500"),
-            price: oneDollar.toString(),
-            side: true,
-            user: accounts[0],
-            expiration: sevenDays,
-            targetTracer: tracer.address,
-            nonce: 0,
-        }
-
-        const types = {
-            EIP712Domain: domain,
-            LimitOrder: limitOrder,
-        }
-
-        const data = {
-            domain: domainData,
-            primaryType: "LimitOrder",
-            message: makeOrder,
-            types: types,
-        }
-
-        const signer = web3.utils.toChecksumAddress(accounts[0])
-        //@ts-ignore
-        await web3.currentProvider!.send(
-            {
-                method: "eth_signTypedData",
-                params: [signer, data],
-                from: signer,
-            },
-            //@ts-ignore
-            async (err, result) => {
-                let parsedSig = result.result.substring(2)
-                const r = "0x" + parsedSig.substring(0, 64)
-                const s = "0x" + parsedSig.substring(64, 128)
-                const v = parseInt(parsedSig.substring(128, 130), 16)
-                let sigResult = await trader.verify(accounts[0], makeOrder, r, s, v)
-                //assert.equal(sigResult, true)
-            }
-        )
-    })
-
-    it("Detects replay attacks in the same batch", async () => {
-        let makes = [
-            {
-                amount: web3.utils.toWei("200"),
-                price: oneDollar.toString(),
-                side: true,
-                user: accounts[0],
-                expiration: sevenDays,
-                targetTracer: tracer.address,
-                nonce: 0,
-            },
-            {
-                amount: web3.utils.toWei("200"),
-                price: oneDollar.toString(),
-                side: true,
-                user: accounts[0],
-                expiration: sevenDays,
-                targetTracer: tracer.address,
-                nonce: 1,
-            },
-        ]
-        let takes = [
-            {
-                amount: web3.utils.toWei("200"),
-                price: oneDollar.toString(),
-                side: false,
-                user: accounts[1],
-                expiration: sevenDays,
-                targetTracer: tracer.address,
-                nonce: 0,
-            },
-        ]
-
-        let takesReplay = [
-            {
-                amount: web3.utils.toWei("200"),
-                price: oneDollar.toString(),
-                side: false,
-                user: accounts[1],
-                expiration: sevenDays,
-                targetTracer: tracer.address,
-                nonce: 0,
-            },
-        ]
-
-        let signedTakesNormal: any = await Promise.all(await signOrders(takes, domain, domainData, limitOrder))
-        let signedTakesReplay: any = await Promise.all(await signOrders(takesReplay, domain, domainData, limitOrder))
-        let signedMakes: any = await Promise.all(await signOrders(makes, domain, domainData, limitOrder))
-        let signedTakes: any = signedTakesNormal.concat(signedTakesReplay)
-
-        await account.deposit(web3.utils.toWei("500"), tracer.address)
-        await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[1] })
-
-        await expectRevert(
-            trader.executeTrade(signedMakes, signedTakes, tracer.address),
-            "TDR: incorrect order sig or nonce"
-        )
-    })
-
-    it("Detects replay attacks in the different batches", async () => {
-        let makes = [
-            {
-                amount: web3.utils.toWei("500"),
-                price: oneDollar.toString(),
-                side: true,
-                user: accounts[0],
-                expiration: sevenDays,
-                targetTracer: tracer.address,
-                nonce: 0,
-            },
-        ]
-        let takes = [
-            {
-                amount: web3.utils.toWei("200"),
-                price: oneDollar.toString(),
-                side: false,
-                user: accounts[1],
-                expiration: sevenDays,
-                targetTracer: tracer.address,
-                nonce: 0,
-            },
-        ]
-
-        let makes2 = [
-            {
-                amount: web3.utils.toWei("500"),
-                price: oneDollar.toString(),
-                side: true,
-                user: accounts[0],
-                expiration: sevenDays,
-                targetTracer: tracer.address,
-                nonce: 1,
-            },
-        ]
-
-        let takesReplay = [
-            {
-                amount: web3.utils.toWei("200"),
-                price: oneDollar.toString(),
-                side: false,
-                user: accounts[1],
-                expiration: sevenDays,
-                targetTracer: tracer.address,
-                nonce: 0,
-            },
-        ]
-
-        let signedTakesNormal: any = await Promise.all(await signOrders(takes, domain, domainData, limitOrder))
-        let signedTakesReplay: any = await Promise.all(await signOrders(takesReplay, domain, domainData, limitOrder))
-        let signedMakes: any = await Promise.all(await signOrders(makes, domain, domainData, limitOrder))
-        let signedMakes2: any = await Promise.all(await signOrders(makes2, domain, domainData, limitOrder))
-        await account.deposit(web3.utils.toWei("500"), tracer.address)
-        await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[1] })
-
-        await trader.executeTrade(signedMakes, signedTakesNormal, tracer.address),
-
-            await expectRevert(
-                trader.executeTrade(signedMakes2, signedTakesReplay, tracer.address),
-                "TDR: incorrect order sig or nonce"
-            )
-    })
-
-    // it("Gas Usage Calc", async () => {
-    //     let makes = []
-    //     let takes = []
-    //     await tracer.deposit(web3.utils.toWei("100"))
-    //     await tracer.deposit(web3.utils.toWei("100"), { from: accounts[1] })
-
-    //     for (var i = 0; i < 50; i++) {
-    //         for (var j = 0; j < i; j++) {
-    //             makes.push({
-    //                 amount: web3.utils.toWei("0.1"),
-    //                 price: oneDollar.toString(),
-    //                 side: true,
-    //                 user: accounts[0],
-    //                 expiration: sevenDays,
-    //                 targetTracer: tracer.address,
-    //             })
-    //             takes.push({
-    //                 amount: web3.utils.toWei("0.1"),
-    //                 price: oneDollar.toString(),
-    //                 side: false,
-    //                 user: accounts[1],
-    //                 expiration: sevenDays,
-    //                 targetTracer: tracer.address,
-    //             })
-    //         }
-
-    //         let signedTakes = await Promise.all(await signOrders(takes, domain, domainData, limitOrder))
-    //         let signedMakes = await Promise.all(await signOrders(makes, domain, domainData, limitOrder))
-
-    //         let batchTxn = await trader.executeTrade(signedMakes, signedTakes, tracer.address)
-    //         console.log(`Makes and Takes ${i + i}. Gas Used ${batchTxn.receipt.gasUsed}`)
-    //         makes = []
-    //         takes = []
-    //     }
-    // })
 })
-
 
 // because of https://stackoverflow.com/questions/40900791/cannot-redeclare-block-scoped-variable-in-unrelated-files
 export { }

--- a/test-ts/functional/Trader.ts
+++ b/test-ts/functional/Trader.ts
@@ -36,9 +36,6 @@ describe("Trader", async () => {
 
     let now
     let sevenDays: any
-    let limitOrder: any
-    let domain: any
-    let domainData: any
 
     before(async () => {
         await configure()

--- a/test-ts/lib/Signing.ts
+++ b/test-ts/lib/Signing.ts
@@ -1,0 +1,84 @@
+/* Support types for signing */
+export const domain = [
+    { name: "name", type: "string" },
+    { name: "version", type: "string" },
+    { name: "chainId", type: "uint256" },
+    { name: "verifyingContract", type: "address" },
+]
+
+export const limitOrder = [
+    { name: "amount", type: "uint256" },
+    { name: "price", type: "int256" },
+    { name: "side", type: "bool" },
+    { name: "user", type: "address" },
+    { name: "expiration", type: "uint256" },
+    { name: "targetTracer", type: "address" },
+    { name: "nonce", type: "uint256" },
+]
+
+export function domainData(trader_address: string) {
+    return {
+        name: "Tracer Protocol",
+        version: "1.0",
+        chainId: 1337,
+        verifyingContract: trader_address,
+    }
+}
+
+/* Helpers for signing */
+
+//@ts-ignore
+export const signOrder = async (web3, signingAccount, data, callback) => {
+    const signer = web3.utils.toChecksumAddress(signingAccount)
+    return new Promise((resolve, reject) => {
+        web3.currentProvider.send(
+            {
+                method: "eth_signTypedData",
+                params: [signer, data],
+                from: signer,
+            },
+            //@ts-ignore
+            async (err, result) => {
+                if (err) {
+                    reject(err)
+                }
+                let parsedSig = result.result.substring(2)
+                const r = "0x" + parsedSig.substring(0, 64)
+                const s = "0x" + parsedSig.substring(64, 128)
+                const v = parseInt(parsedSig.substring(128, 130), 16) //130 hex = 65bytes
+                return resolve([r, s, v])
+            }
+        )
+    })
+}
+
+
+//Process and sign orders
+//@ts-ignore
+export const signOrders = async (web3, orders, traderAddress) => {
+    let _domainData = domainData(traderAddress)
+    //@ts-ignore
+    return await orders.map(async (order) => {
+        let type = {
+            EIP712Domain: domain,
+            LimitOrder: limitOrder,
+        }
+
+        let dataToSign = {
+            domain: _domainData,
+            primaryType: "LimitOrder",
+            message: order,
+            types: type,
+        }
+
+        //@ts-ignore
+        let signedData: [string, string, string] = await signOrder(web3, order.user, dataToSign)
+
+        return {
+            order: order,
+            sigR: signedData[0],
+            sigS: signedData[1],
+            sigV: signedData[2],
+        }
+    })
+}

--- a/test-ts/unit/Trader.ts
+++ b/test-ts/unit/Trader.ts
@@ -131,6 +131,7 @@ describe("Trader Shim unit tests", async () => {
             })
         })
 
+        //TODO: Do we still want this test. Actually is testing logic in SimpleDex now
         context("When there is a price mismatch", () => {
             it("reverts", async () => {
                 let makers: any = badMakers;
@@ -143,7 +144,7 @@ describe("Trader Shim unit tests", async () => {
 
                 await expectRevert(
                     trader.executeTrade(signedMakers, signedTakers, market),
-                    "TDR: Price mismatch"
+                    "SDX: Price mismatch"
                 )
             })
         })

--- a/test-ts/unit/Trader.ts
+++ b/test-ts/unit/Trader.ts
@@ -8,10 +8,8 @@ import { accounts, configure, web3 } from "../configure"
 import { Trader } from "../artifacts"
 
 describe("Trader Shim unit tests", async () => {
-    let deployed;
     let trader: TraderInstance;
     let tracer: TracerInstance;
-    let account: AccountInstance
     
     let sampleMakers: any;
     let sampleTakers: any;
@@ -30,7 +28,6 @@ describe("Trader Shim unit tests", async () => {
 
         trader = await Trader.new()
         tracer = deployed.tracer
-        account = deployed.account
 
         //Get each user to "deposit" 100 tokens into the platform and approve the trader
         for (var i = 0; i < 6; i++) {
@@ -143,9 +140,6 @@ describe("Trader Shim unit tests", async () => {
                 /* sign orders for submission */
                 let signedMakers: any = await Promise.all(await signOrders(web3, makers, trader.address));
                 let signedTakers: any = await Promise.all(await signOrders(web3, takers, trader.address));
-
-                // await account.deposit(web3.utils.toWei("500"), tracer.address)
-                // await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[1] })
 
                 await expectRevert(
                     trader.executeTrade(signedMakers, signedTakers, market),

--- a/test-ts/unit/Trader.ts
+++ b/test-ts/unit/Trader.ts
@@ -131,24 +131,6 @@ describe("Trader Shim unit tests", async () => {
             })
         })
 
-        //TODO: Do we still want this test. Actually is testing logic in SimpleDex now
-        context("When there is a price mismatch", () => {
-            it("reverts", async () => {
-                let makers: any = badMakers;
-                let takers: any = sampleTakers;
-                let market: string = tracer.address;
-
-                /* sign orders for submission */
-                let signedMakers: any = await Promise.all(await signOrders(web3, makers, trader.address));
-                let signedTakers: any = await Promise.all(await signOrders(web3, takers, trader.address));
-
-                await expectRevert(
-                    trader.executeTrade(signedMakers, signedTakers, market),
-                    "SDX: Price mismatch"
-                )
-            })
-        })
-
         context("When both input arrays are valid", () => {
             it("passes", async () => {
                 let makers: any = sampleMakers;

--- a/test-ts/unit/Trader.ts
+++ b/test-ts/unit/Trader.ts
@@ -1,0 +1,173 @@
+//@ts-ignore
+import { BN, expectRevert, time } from "@openzeppelin/test-helpers"
+import assert from "assert"
+import { setupContractsAndTracer } from "../lib/Setup"
+import { AccountInstance, TracerInstance, TraderInstance } from "../../types/truffle-contracts"
+import { signOrder, signOrders, domain, domainData, limitOrder } from "../lib/Signing"
+import { accounts, configure, web3 } from "../configure"
+import { Trader } from "../artifacts"
+
+describe("Trader Shim unit tests", async () => {
+    let deployed;
+    let trader: TraderInstance;
+    let tracer: TracerInstance;
+    let account: AccountInstance
+    
+    let sampleMakers: any;
+    let sampleTakers: any;
+    let badMakers: any;
+
+    let now
+    let sevenDays: any
+
+    before(async () => {
+        await configure()
+    })
+
+    beforeEach(async () => {
+        //Setup all contracts
+        let deployed = await setupContractsAndTracer(accounts)
+
+        trader = await Trader.new()
+        tracer = deployed.tracer
+        account = deployed.account
+
+        //Get each user to "deposit" 100 tokens into the platform and approve the trader
+        for (var i = 0; i < 6; i++) {
+            await tracer.setUserPermissions(trader.address, true, { from: accounts[i] })
+        }
+
+        now = await time.latest()
+        sevenDays = parseInt(now) + 604800 //7 days from now
+    
+        sampleMakers = [
+            {
+                amount: "5000000000000000000",
+                price: "100000000",
+                side: true,
+                user: accounts[1],
+                expiration: sevenDays,
+                targetTracer: tracer.address,
+                nonce: 0,
+            },
+            {
+                amount: "5000002200000000000",
+                price: "100000088",
+                side: false,
+                user: accounts[0],
+                expiration: sevenDays,
+                targetTracer: tracer.address,
+                nonce: 0,
+            }
+        ];
+    
+        sampleTakers = [
+            {
+                amount: "5000000000000000000",
+                price: "100000000",
+                side: true,
+                user: accounts[2],
+                expiration: sevenDays,
+                targetTracer: tracer.address,
+                nonce: 0,
+            },
+            {
+                amount: "5000002200000000000",
+                price: "100000088",
+                side: false,
+                user: accounts[2],
+                expiration: sevenDays,
+                targetTracer: tracer.address,
+                nonce: 1,
+            }
+        ];
+
+        badMakers = [
+            {
+                amount: "5000000000000000000",
+                price: "100000011",
+                side: true,
+                user: accounts[1],
+                expiration: sevenDays,
+                targetTracer: tracer.address,
+                nonce: 0,
+            },
+            {
+                amount: "5000002200000000000",
+                price: "100000088",
+                side: false,
+                user: accounts[0],
+                expiration: sevenDays,
+                targetTracer: tracer.address,
+                nonce: 0,
+            }
+        ];
+    })
+
+    describe("executeTrade", () => {
+        context("When input array lengths differ", () => {
+            it("reverts", async () => {
+                let makers: any = sampleMakers;
+                let takers: any = sampleTakers.slice(0, 1);
+                let market: string = tracer.address;
+
+                /* sign orders for submission */
+                let signedMakers: any = await Promise.all(await signOrders(web3, makers, trader.address));
+                let signedTakers: any = await Promise.all(await signOrders(web3, takers, trader.address));
+
+                await expectRevert(
+                    trader.executeTrade(signedMakers, signedTakers, market),
+                    "TDR: Lengths differ"
+                )
+            })
+        })
+
+        context("When input arrays are both empty", () => {
+            it("reverts", async () => {
+                let makers: any = [];
+                let takers: any = [];
+                let market: string = tracer.address;
+
+                await expectRevert(
+                    trader.executeTrade(makers, takers, market),
+                    "TDR: Received empty arrays")
+            })
+        })
+
+        context("When there is a price mismatch", () => {
+            it("reverts", async () => {
+                let makers: any = badMakers;
+                let takers: any = sampleTakers;
+                let market: string = tracer.address;
+
+                /* sign orders for submission */
+                let signedMakers: any = await Promise.all(await signOrders(web3, makers, trader.address));
+                let signedTakers: any = await Promise.all(await signOrders(web3, takers, trader.address));
+
+                // await account.deposit(web3.utils.toWei("500"), tracer.address)
+                // await account.deposit(web3.utils.toWei("500"), tracer.address, { from: accounts[1] })
+
+                await expectRevert(
+                    trader.executeTrade(signedMakers, signedTakers, market),
+                    "TDR: Price mismatch"
+                )
+            })
+        })
+
+        context("When both input arrays are valid", () => {
+            it("passes", async () => {
+                let makers: any = sampleMakers;
+                let takers: any = sampleTakers;
+                let market: string = tracer.address;
+
+                /* sign orders for submission */
+                let signedMakers: any = await Promise.all(await signOrders(web3, makers, trader.address));
+                let signedTakers: any = await Promise.all(await signOrders(web3, takers, trader.address));
+
+                assert(trader.executeTrade(signedMakers, signedTakers, market));
+            })
+        })
+    })
+})
+
+export {}


### PR DESCRIPTION
# Motivation
This branch contains updated `trader.sol` code to improve the way off chain orders. are handled on chain. To do this, the simple dex and tracer contracts are also updated

# Changes
- Change the executeTrades function in the trader contract to match 1-1
- introduce a matchOrders function in tracer.sol
- introduce a mapping of order hash to id in simple dex