### PR TITLE
Removed deprecated calculations. Fixed Trader.sol tests

### DIFF
--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -665,26 +665,6 @@ contract Account is IAccount, Ownable {
     }
 
     /**
-     * @notice Returns a users margin in a particular Tracer Market
-     * @dev Will not throw if margin is negative
-     * @param account The address whose account is queried
-     * @param market The address of the relevant Tracer market
-     * @return the margin of the account (positive or negative)
-     */
-    function unsafeGetUserMargin(address account, address market) public override view returns (int256) {
-        Types.AccountBalance memory accountBalance = balances[market][account];
-        ITracer _tracer = ITracer(market);
-        return
-            Balances.calcMarginPercent(
-                accountBalance.base,
-                accountBalance.quote,
-                pricing.fairPrices(market),
-                uint256(accountBalance.lastUpdatedGasPrice).mul(_tracer.LIQUIDATION_GAS_COST()),
-                _tracer.priceMultiplier()
-            );
-    }
-
-    /**
      * @param newReceiptContract The new instance of Receipt.sol
      */
     function setReceiptContract(address newReceiptContract) public override onlyOwner() {

--- a/contracts/Interfaces/IAccount.sol
+++ b/contracts/Interfaces/IAccount.sol
@@ -83,8 +83,6 @@ interface IAccount {
 
     function getUserMinMargin(address account, address market) external view returns (int256);
 
-    function unsafeGetUserMargin(address account, address market) external view returns (int256);
-
     function tracerLeveragedNotionalValue(address market) external view returns(int256);
 
     function tvl(address market) external view returns(uint256);

--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -69,6 +69,11 @@ contract Trader {
             uint256 makeOrderId = grabOrder(makers, i, market);
             uint256 takeOrderId = grabOrder(takers, i, market);
 
+            address maker = makers[i].order.user;
+            address taker = takers[i].order.user;
+            nonces[maker]++;
+            nonces[taker]++;
+
             // match orders
             ITracer(market).matchOrders(makeOrderId, takeOrderId);
 

--- a/test-ts/functional/Tracer.ts
+++ b/test-ts/functional/Tracer.ts
@@ -686,11 +686,8 @@ describe("Tracer", async () => {
     context("Calculates Margin Correctly", async () => {
         it("Gives correct margin on deposits", async () => {
             await account.deposit(web3.utils.toWei("500"), tracer.address)
-            //let balance = await account.getBalance(accounts[0], tracer.address)
-            // let gasCost = web3.utils.toWei("7348050000", "gwei") //250 gwei * gas used of 63516 8 eth price of 450
-            // let margin = await tracer.calcMarginPercent(balance[0].toString(), balance[1].toString(), gasCost)
-            let margin = await account.unsafeGetUserMargin(accounts[0], tracer.address)
-            assert.equal(margin.toString(), "10000")
+            let margin = await account.getUserMargin(accounts[0], tracer.address)
+            assert.equal(margin.toString(), web3.utils.toWei("500"))
         })
 
         it("Factors in the gas cost of liquidation while calculating minimum margin", async () => {
@@ -728,9 +725,6 @@ describe("Tracer", async () => {
 
             //Check margin of leveraged account (SHORT)
             //margin is ((600 - 42.87) / 500) - 1
-            // let balance = await tracer.getBalance(accounts[1])
-            // let gasCost = new BN("714555000000000000000000000")
-            // let margin = await tracer.calcMarginPercent(balance[0].toString(), balance[1].toString(), gasCost)
             let margin = await account.getUserMargin(accounts[0], tracer.address)
             let margin2 = await account.getUserMargin(accounts[1], tracer.address)
             let notional1 = await account.getUserNotionalValue(accounts[0], tracer.address)

--- a/test-ts/unit/Trader.ts
+++ b/test-ts/unit/Trader.ts
@@ -108,24 +108,6 @@ describe("Trader Shim unit tests", async () => {
     })
 
     describe("executeTrade", () => {
-        context("When order is executed twice", () => {
-            it("passes", async () => {
-                let makers: any = sampleMakers;
-                let takers: any = sampleTakers;
-                let market: string = tracer.address;
-
-                /* sign orders for submission */
-                let signedMakers: any = await Promise.all(await signOrders(web3, makers, trader.address));
-                let signedTakers: any = await Promise.all(await signOrders(web3, takers, trader.address));
-
-                assert(await trader.executeTrade(signedMakers, signedTakers, market));
-                await expectRevert(
-                    trader.executeTrade(signedMakers, signedTakers, market),
-                    "TDR: Incorrect nonce"
-                );
-            })
-        })
-
         context("When input array lengths differ", () => {
             it("reverts", async () => {
                 let makers: any = sampleMakers;


### PR DESCRIPTION
### Motivation
Functions that use the calculations from the old accounting system were still in the codebase. These should be deleted.

Also, a test in the Trader.sol unit tests was passing incorrectly 

### Changes
- Deleted `LibBalance.sol`'s safeCalcMarginPercent, calcMarginPercent, calcPositiveNegative
    - Changed tests using these calculations to the new system.
    - Deleted `Account.unsafeGetUserMargin` 
- Increment nonce on order making in Trader.sol
- Changed tests in unit/Trader.ts
    - Changed order sides to be opposite of order being matched against
    - Added a test for when order is made twice (invalid)
    - Check that `Trader.executeTrade` is actually incrementing order nonce.