### PR TITLE
Set solidity version to 0.6.12

### DIFF
--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 import "./Interfaces/ITracer.sol";
 import "./Interfaces/IOracle.sol";

--- a/contracts/DEX/SimpleDex.sol
+++ b/contracts/DEX/SimpleDex.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/DeployerV1.sol
+++ b/contracts/DeployerV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 import "./Tracer.sol";
 import "./Interfaces/IDeployer.sol";

--- a/contracts/GasOracle.sol
+++ b/contracts/GasOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >= 0.6.0;
+pragma solidity ^0.6.12;
 
 import "./Interfaces/IOracle.sol";
 import "./lib/LibMath.sol";

--- a/contracts/Gov.sol
+++ b/contracts/Gov.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/math/SignedSafeMath.sol";

--- a/contracts/InsurancePoolToken.sol
+++ b/contracts/InsurancePoolToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/Interfaces/IAccount.sol
+++ b/contracts/Interfaces/IAccount.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 import "./Types.sol";
 

--- a/contracts/Interfaces/IDeployer.sol
+++ b/contracts/Interfaces/IDeployer.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 interface IDeployer {
 

--- a/contracts/Interfaces/IDex.sol
+++ b/contracts/Interfaces/IDex.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 import "./Types.sol";
 
 interface IDex {

--- a/contracts/Interfaces/IGov.sol
+++ b/contracts/Interfaces/IGov.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 interface IGov {

--- a/contracts/Interfaces/IInsurance.sol
+++ b/contracts/Interfaces/IInsurance.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 interface IInsurance {
 

--- a/contracts/Interfaces/IOracle.sol
+++ b/contracts/Interfaces/IOracle.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >= 0.6.0;
+pragma solidity ^0.6.12;
 
 interface IOracle {
 

--- a/contracts/Interfaces/IPricing.sol
+++ b/contracts/Interfaces/IPricing.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 interface IPricing {
     function setFundingRate(address market, int256 price, int256 fundingRate, int256 fundingRateValue) external;

--- a/contracts/Interfaces/IReceipt.sol
+++ b/contracts/Interfaces/IReceipt.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 import "./Types.sol";
 

--- a/contracts/Interfaces/ITracer.sol
+++ b/contracts/Interfaces/ITracer.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 interface ITracer {
 

--- a/contracts/Interfaces/ITracerFactory.sol
+++ b/contracts/Interfaces/ITracerFactory.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 interface ITracerFactory {
 

--- a/contracts/Interfaces/Types.sol
+++ b/contracts/Interfaces/Types.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 interface Types {

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.6.0;
+pragma solidity ^0.6.12;
 
 contract Migrations {
     address public owner;

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >= 0.6.0;
+pragma solidity ^0.6.12;
 
 import "./Interfaces/IOracle.sol";
 

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 import {Types} from "./Interfaces/Types.sol";
 import "./lib/LibMath.sol";

--- a/contracts/Receipt.sol
+++ b/contracts/Receipt.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/math/SignedSafeMath.sol";

--- a/contracts/TestToken.sol
+++ b/contracts/TestToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.6.0;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/Tracer.sol
+++ b/contracts/Tracer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/math/SignedSafeMath.sol";

--- a/contracts/TracerFactory.sol
+++ b/contracts/TracerFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 import "./Interfaces/ITracer.sol";
 import "./Interfaces/IInsurance.sol";

--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./Interfaces/ITracer.sol";

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma experimental ABIEncoderV2;
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 import "./LibMath.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/lib/LibMath.sol
+++ b/contracts/lib/LibMath.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >= 0.6.0;
+pragma solidity ^0.6.12;
 
 library LibMath {
     uint256 private constant POSITIVE_INT256_MAX = 2**255 - 1;

--- a/contracts/lib/SafeMath96.sol
+++ b/contracts/lib/SafeMath96.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 library SafeMath96 {
     function add96(uint96 a, uint96 b) internal pure returns (uint96) {

--- a/contracts/mock/MockTracer.sol
+++ b/contracts/mock/MockTracer.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 
 /**

--- a/contracts/mock/MockTracerFactory.sol
+++ b/contracts/mock/MockTracerFactory.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity ^0.6.12;
 
 import "../Interfaces/ITracer.sol";
 import "../Interfaces/IInsurance.sol";


### PR DESCRIPTION
# Motivation
In order for a code audit to be conducted, sets a standard solidity version across all contracts.

# Changes
- remove range solidity versioning, replace with 0.6.12.