### PR TITLE
Removes pool sync functionality

### DIFF
--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -66,15 +66,28 @@ contract Account is IAccount, Ownable {
     }
 
     /**
+     * @notice Allows am account to deposit on behalf of a user into a specific market
+     * @param amount The amount of margin tokens to be deposited into the Tracer Market account
+     * @param market The address of the tracer market that the margin tokens will be deposited into 
+     */
+    function depositTo(uint256 amount, address market, address user, address depositer) external override {
+        _deposit(amount, market, user, depositer);
+    }
+
+    /**
      * @notice Allows a user to deposit into a margin account of a specific tracer
      * @param amount The amount of margin tokens to be deposited into the Tracer Market account
      * @param market The address of the tracer market that the margin tokens will be deposited into 
      */
-    function deposit(uint256 amount, address market) external override isValidTracer(market) {
+    function deposit(uint256 amount, address market) external override {
+        _deposit(amount, market, msg.sender, msg.sender);
+    }
+
+    function _deposit(uint256 amount, address market, address user, address depositer) internal isValidTracer(market) {
         require(amount > 0, "ACT: Deposit Amount <= 0"); 
-        Types.AccountBalance storage userBalance = balances[market][msg.sender];
+        Types.AccountBalance storage userBalance = balances[market][user];
         address tracerBaseToken = ITracer(market).tracerBaseToken();
-        IERC20(tracerBaseToken).safeTransferFrom(msg.sender, address(this), amount);
+        IERC20(tracerBaseToken).safeTransferFrom(depositer, address(this), amount);
         userBalance.base = userBalance.base.add(amount.toInt256());
         userBalance.deposited = userBalance.deposited.add(amount);
         int256 originalLeverage = userBalance.totalLeveragedValue;
@@ -82,12 +95,12 @@ contract Account is IAccount, Ownable {
         _updateAccountLeverage(userBalance.quote,
             pricing.fairPrices(market),
             userBalance.base,
-            msg.sender,
+            user,
             market,
             originalLeverage
         );
         tvl[market] = tvl[market].add(amount);
-        emit Deposit(msg.sender, amount, market);
+        emit Deposit(user, amount, market);
     }
 
     /**

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -118,11 +118,10 @@ contract Insurance is IInsurance, Ownable {
      * @param market the tracer contract that the insurance pool is for.
      */
     function updatePoolAmount(address market) external override {
-        ITracer _tracer = ITracer(market);
-        IERC20 tracerBaseToken = IERC20(_tracer.tracerBaseToken());
-        (int256 margin, , , , , ) = account.getBalance(address(this), market);
-        if (margin > 0) {
-            account.withdraw(uint(margin), market);
+        (int256 base, , , , , ) = account.getBalance(address(this), market);
+        if (base > 0) {
+            account.withdraw(uint(base), market);
+            pools[market].amount = pools[market].amount.add(uint(base));
         }
     }
 

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -124,8 +124,6 @@ contract Insurance is IInsurance, Ownable {
         if (margin > 0) {
             account.withdraw(uint(margin), market);
         }
-        // Sync with the balance of the tracer margin token
-        pools[market].amount = tracerBaseToken.balanceOf(address(this));
     }
 
     /**

--- a/contracts/Interfaces/IAccount.sol
+++ b/contracts/Interfaces/IAccount.sol
@@ -6,6 +6,8 @@ import "./Types.sol";
 interface IAccount {
     function deposit(uint256 amount, address market) external;
 
+    function depositTo(uint256 amount, address market, address user, address depositer) external;
+
     function withdraw(uint256 amount, address market) external;
 
     function settle(

--- a/test-ts/functional/Insurance.ts
+++ b/test-ts/functional/Insurance.ts
@@ -100,15 +100,13 @@ describe("Insurance", async () => {
             await insurance.stake(web3.utils.toWei("5"), tracers[0].address)
 
             //Insurance state: 5 margin tokens, 5 pool tokens
-
             let tracerMarginAddr = await tracers[0].tracerBaseToken()
             let tracerBaseToken = await TestToken.at(tracerMarginAddr)
             await tracerBaseToken.transfer(insurance.address, web3.utils.toWei("5"))
 
-            //Sync the insurance pool with its margin holding
+            //Deposit into insurance pool and sync holdings
+            await account.depositTo(web3.utils.toWei("5"), tracers[0].address, insurance.address, accounts[0])
             await insurance.updatePoolAmount(tracers[0].address)
-
-            // let poolTokensBefore = await insurance.getPoolUserBalance(tracers[0].address, accounts[1])
 
             //Insurance state: margin: 10, outstandingPoolTokens: 5. (2:1)
             await tokens[0].approve(insurance.address, web3.utils.toWei("10"), { from: accounts[1] })
@@ -143,12 +141,11 @@ describe("Insurance", async () => {
             await insurance.stake(web3.utils.toWei("5"), tracers[0].address)
 
             //Insurance state: 5 margin tokens, 5 pool tokens
-
             let tracerMarginAddr = await tracers[0].tracerBaseToken()
             let tracerBaseToken = await TestToken.at(tracerMarginAddr)
-            await tracerBaseToken.transfer(insurance.address, web3.utils.toWei("5"))
 
             //Sync the insurance pool with its margin holding
+            await account.depositTo(web3.utils.toWei("5"), tracers[0].address, insurance.address, accounts[0])
             await insurance.updatePoolAmount(tracers[0].address)
 
             //Insurance state: margin: 10, outstandingPoolTokens: 5


### PR DESCRIPTION
# Motivation
In the `updatePoolAmount` function, there was a line that would sync the insurance pool with the balance of its underlying collateral token. The problem with this is that if a pool uses the same collateral token as another pool, and the insurance contract holds 100 of these underlying tokens, both pools would have their internal balance set to 100. This opens up the insurance pool to malicious market attacks where a legitimate pool can be drained by a illegitimate market.

# Changes
- remove the `pools[market].amount = tracerBaseToken.balanceOf(address(this));` line. Insurance pools now can only be topped up via withdrawing from the account contract directly. This is in line with intended functionality as the insurance funding rate is paid to the pools account for each specific market.
- introduces a depositTo function for the account contract to allow external accounts to top up another account. Not only useful for tests but may be used to build more complex account systems on top of the current account contract.