### PR TITLE
depositTo Patch

### DIFF
--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -70,10 +70,9 @@ contract Account is IAccount, Ownable {
      * @param amount The amount of base tokens to be deposited into the Tracer Market account
      * @param market The address of the tracer market that the margin tokens will be deposited into
      * @param user the user whos account the deposit is being made into
-     * @param depositer the address who is depositing the funds
      */
-    function depositTo(uint256 amount, address market, address user, address depositer) external override {
-        _deposit(amount, market, user, depositer);
+    function depositTo(uint256 amount, address market, address user) external override {
+        _deposit(amount, market, user, msg.sender);
     }
 
     /**

--- a/contracts/Interfaces/IAccount.sol
+++ b/contracts/Interfaces/IAccount.sol
@@ -6,7 +6,7 @@ import "./Types.sol";
 interface IAccount {
     function deposit(uint256 amount, address market) external;
 
-    function depositTo(uint256 amount, address market, address user, address depositer) external;
+    function depositTo(uint256 amount, address market, address user) external;
 
     function withdraw(uint256 amount, address market) external;
 

--- a/test-ts/functional/Insurance.ts
+++ b/test-ts/functional/Insurance.ts
@@ -105,7 +105,7 @@ describe("Insurance", async () => {
             await tracerBaseToken.transfer(insurance.address, web3.utils.toWei("5"))
 
             //Deposit into insurance pool and sync holdings
-            await account.depositTo(web3.utils.toWei("5"), tracers[0].address, insurance.address, accounts[0])
+            await account.depositTo(web3.utils.toWei("5"), tracers[0].address, insurance.address)
             await insurance.updatePoolAmount(tracers[0].address)
 
             //Insurance state: margin: 10, outstandingPoolTokens: 5. (2:1)
@@ -145,7 +145,7 @@ describe("Insurance", async () => {
             let tracerBaseToken = await TestToken.at(tracerMarginAddr)
 
             //Sync the insurance pool with its margin holding
-            await account.depositTo(web3.utils.toWei("5"), tracers[0].address, insurance.address, accounts[0])
+            await account.depositTo(web3.utils.toWei("5"), tracers[0].address, insurance.address)
             await insurance.updatePoolAmount(tracers[0].address)
 
             //Insurance state: margin: 10, outstandingPoolTokens: 5


### PR DESCRIPTION
# motivation
The deposit to function was accepting a depositer param, however this should have just used `msg.sender` to enforce the person calling the function to deposit into another users account.

# changes
- remove depositer param
- use msg.sender