### PR TITLE
Add percentage factor offset to funding rate sensitivity

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -12,6 +12,7 @@ import "@openzeppelin/contracts/math/SignedSafeMath.sol";
 
 contract Pricing is IPricing {
     uint256 private constant DIVIDE_PRECISION = 100000000; // 10^7
+    uint256 private constant PERCENT_FACTOR = 10000; // 10^5; supports 5 decimal places for funding rate sensitivity
     using SafeMath for uint256;
     using SignedSafeMath for int256;
     using LibMath for uint256;
@@ -95,9 +96,9 @@ contract Pricing is IPricing {
         ITracer _tracer = ITracer(market);
         int256 timeValue = timeValues[market];
         (int256 underlyingTWAP, int256 deriativeTWAP) = getTWAPs(market, _tracer.currentHour());
-        int256 newFundingRate = ((deriativeTWAP).sub(underlyingTWAP).sub(timeValue)).mul(
+        int256 newFundingRate = (((deriativeTWAP).sub(underlyingTWAP).sub(timeValue)).mul(
             _tracer.FUNDING_RATE_SENSITIVITY().toInt256()
-        );
+        )).div(PERCENT_FACTOR.toInt256());
         // set the index to the last funding Rate confirmed funding rate (-1)
         uint256 fundingIndex = currentFundingIndex[market] - 1;
 

--- a/test-ts/lib/Setup.ts
+++ b/test-ts/lib/Setup.ts
@@ -282,7 +282,7 @@ export async function setupContractsAndTracer(accounts: Truffle.Accounts): Promi
             account.address,
             pricing.address,
             maxLeverage,
-            1 //funding rate sensitivity
+            new BN("10000") // funding rate sensitivity; supporting up to 5 decimal places
         ]
     )
 


### PR DESCRIPTION
# Motivation
Lets funding rate sensitivity support up to 5 decimal places by adding a factor offset of 10^5. The funding rate sensitivity can now be as low as 0.00001 instead of the minimum of 1 previously. 

# Changes
- Offset funding rate sensitivity by percent factor (10^5)
- Change funding rate sensitivity in `Setup.ts` to be increased by new percent factor