### PR TITLE
Deployment script now sets up new accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,18 @@ yarn test
 
 ## Tests
 Tests use the mocha testing framework. We avoid using truffle globals such as to enable multi-core parrallel testing. Instead of using the global `artifacts` variable from the Truffle environment, contracts are instantiated in our own custom `artifacts.ts` file. This enables the child processes instantiated by mocha to access the Truffle contracts. We also use use ganache-core for testing as opposed to connecting to a server endpoint or using the Truffle web3 global. For more info check out this answer https://github.com/trufflesuite/truffle/issues/1707#issuecomment-748313997.
+
+## Migrations
+#### To deploy to Kovan
+1) Add a file called `kovan.secret`, including only your Kovan RPC endpoint.
+2) Add a file called `mnemonic.secret`, including only the mnemonic of the account which you want to deploy from. This account must have enough KETH.
+3) Add a file called `priv_key.secret`, including the private key of the account which you want to deploy from (the same as from step 2).
+4) Change `numAccounts` in the `migrations-ts/2_deploy_contracts.ts`.
+5) Run `yarn compile:migrations && yarn migrate --reset --network kovan`.
+- This may take a while, depending on how big `numAccounts` is.
+- The private keys of the newly generated accounts are output to ./private_keys.txt
+
+#### To deploy to development (localhost)
+1) Run `ganache-cli -l 80000000000`
+2) In a separate window, run `yarn compile:migrations && yarn migrate --reset --network development`
+3) There will be errors when trying to read from different files required for Kovan deployment. You can safely ignore these.


### PR DESCRIPTION
### Motivation
Deploying to Kovan is nice, but there is still further setup required in that you need to go through the process of depositing to a tracer, setting Trader.sol permissions, etc.

### Changes
Migration script now does the following:
- Creates a number of accounts
- For each account:
    - Transfer TST tokens to it
    - Deposit TST tokens to Account.sol for the TST market
    - Set Trader.sol permission to trader the TST token
    - Output private key to `./private_keys.txt`
 - Nicer data output for relevant address data, etc.