### PR TITLE
Removed all references to Types.AccountBalance.deposited

### DIFF
--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -98,7 +98,6 @@ contract Account is IAccount, Ownable {
         address tracerBaseToken = ITracer(market).tracerBaseToken();
         IERC20(tracerBaseToken).safeTransferFrom(depositer, address(this), amount);
         userBalance.base = userBalance.base.add(amount.toInt256());
-        userBalance.deposited = userBalance.deposited.add(amount);
         int256 originalLeverage = userBalance.totalLeveragedValue;
         
         _updateAccountLeverage(userBalance.quote,
@@ -135,7 +134,6 @@ contract Account is IAccount, Ownable {
         address tracerBaseToken = _tracer.tracerBaseToken();
         IERC20(tracerBaseToken).safeTransfer(msg.sender, amount);
         userBalance.base = userBalance.base.sub(amount.toInt256());
-        userBalance.deposited = userBalance.deposited.sub(amount);
         int256 originalLeverage = userBalance.totalLeveragedValue;
         _updateAccountLeverage(userBalance.quote, pricing.fairPrices(market), userBalance.base, msg.sender, market, originalLeverage);
         
@@ -195,7 +193,6 @@ contract Account is IAccount, Ownable {
                 accountBalance.base = accountBalance.base.sub(changeInInsuranceBalance);
                 insuranceBalance.base = insuranceBalance.base.add(changeInInsuranceBalance);
                 // uint is safe since changeInInsuranceBalance > 0
-                insuranceBalance.deposited = insuranceBalance.deposited.add(uint256(changeInInsuranceBalance));
             }
         }
 
@@ -461,7 +458,6 @@ contract Account is IAccount, Ownable {
         userBalance.base = base;
         userBalance.quote = quote;
         userBalance.totalLeveragedValue = leverage;
-        userBalance.deposited = deposited;
         userBalance.lastUpdatedGasPrice = IOracle(_tracer.gasPriceOracle()).latestAnswer();
     }
 
@@ -578,7 +574,6 @@ contract Account is IAccount, Ownable {
             int256 base,
             int256 quote,
             int256 totalLeveragedValue,
-            uint256 deposited,
             int256 lastUpdatedGasPrice,
             uint256 lastUpdatedIndex
         )
@@ -588,7 +583,6 @@ contract Account is IAccount, Ownable {
             userBalance.base,
             userBalance.quote,
             userBalance.totalLeveragedValue,
-            userBalance.deposited,
             userBalance.lastUpdatedGasPrice,
             userBalance.lastUpdatedIndex
         );

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -118,7 +118,7 @@ contract Insurance is IInsurance, Ownable {
      * @param market the tracer contract that the insurance pool is for.
      */
     function updatePoolAmount(address market) external override {
-        (int256 base, , , , , ) = account.getBalance(address(this), market);
+        (int256 base, , , , ) = account.getBalance(address(this), market);
         if (base > 0) {
             account.withdraw(uint(base), market);
             pools[market].amount = pools[market].amount.add(uint(base));

--- a/contracts/Interfaces/IAccount.sol
+++ b/contracts/Interfaces/IAccount.sol
@@ -40,12 +40,11 @@ interface IAccount {
         external
         view
         returns (
-            int256,
-            int256,
-            int256,
-            uint256,
-            int256,
-            uint256
+            int256 margin,
+            int256 position,
+            int256 totalLeveragedValue,
+            int256 lastUpdatedGasPrice,
+            uint256 lastUpdatedIndex
         );
 
     function updateAccount(

--- a/contracts/Interfaces/ITracer.sol
+++ b/contracts/Interfaces/ITracer.sol
@@ -54,7 +54,6 @@ interface ITracer {
         int256 margin,
         int256 position,
         int256 totalLeveragedValue,
-        uint256 deposited,
         int256 lastUpdatedGasPrice,
         uint256 lastUpdatedIndex
     );

--- a/contracts/Interfaces/Types.sol
+++ b/contracts/Interfaces/Types.sol
@@ -5,7 +5,6 @@ pragma experimental ABIEncoderV2;
 interface Types {
 
     struct AccountBalance {
-        uint256 deposited;
         int256 base; // The amount of units in the base asset
         int256 quote; // The amount of units in the quote asset
         int256 totalLeveragedValue;

--- a/contracts/Tracer.sol
+++ b/contracts/Tracer.sol
@@ -141,7 +141,7 @@ contract Tracer is ITracer, SimpleDex, Ownable {
     ) public override isPermissioned(maker) returns (uint256) {
         {
             // Validate in its own context to help stack
-            (int256 base, int256 quote, , , , ) = accountContract.getBalance(maker, address(this));
+            (int256 base, int256 quote, , , ) = accountContract.getBalance(maker, address(this));
 
             // Check base will hold up after trade
             (int256 baseAfterTrade, int256 quoteAfterTrade) = Balances.safeCalcTradeMargin(
@@ -311,7 +311,7 @@ contract Tracer is ITracer, SimpleDex, Ownable {
      */
     function settle(address account) public override {
         // Get account and global last updated indexes
-        (, , , , , uint256 accountLastUpdatedIndex) = accountContract.getBalance(account, address(this));
+        (, , , , uint256 accountLastUpdatedIndex) = accountContract.getBalance(account, address(this));
         uint256 currentGlobalFundingIndex = pricingContract.currentFundingIndex(address(this));
 
         // Only settle account if its last updated index was before the current global index
@@ -439,7 +439,6 @@ contract Tracer is ITracer, SimpleDex, Ownable {
         int256 margin,
         int256 position,
         int256 totalLeveragedValue,
-        uint256 deposited,
         int256 lastUpdatedGasPrice,
         uint256 lastUpdatedIndex
     ) {


### PR DESCRIPTION
### Motivation
We don't use `Types.AccountBalance.deposited` anymore. And it actually creates a bug in `withdraw` where you can never withdraw more than you deposit (i.e. can't withdraw profit)
### Changes
- Removed any reference to `AccountBalance.deposited`

Closes #26 