### PR TITLE
Trader nonce validation

### DIFF
--- a/test-ts/unit/Trader.ts
+++ b/test-ts/unit/Trader.ts
@@ -148,10 +148,23 @@ describe("Trader Shim unit tests", async () => {
                 let signedTakers: any = await Promise.all(await signOrders(web3, takers, trader.address));
 
                 assert(await trader.executeTrade(signedMakers, signedTakers, market));
+            })
+
+            it("increments nonces correctly", async () => {
+                let makers: any = sampleMakers;
+                let takers: any = sampleTakers;
+                let market: string = tracer.address;
+
+                /* sign orders for submission */
+                let signedMakers: any = await Promise.all(await signOrders(web3, makers, trader.address));
+                let signedTakers: any = await Promise.all(await signOrders(web3, takers, trader.address));
+
+                await trader.executeTrade(signedMakers, signedTakers, market);
+            
                 assert.equal(await trader.nonces(accounts[0]), "1")
                 assert.equal(await trader.nonces(accounts[1]), "1")
                 assert.equal(await trader.nonces(accounts[2]), "2")
-            })
+            });
         })
     })
 })


### PR DESCRIPTION
# Motivation
Currently, the Trader shim (in `Trader.sol`) increments account nonces even if an order is not fully matched. This obviously breaks partial order functionality because an order can only have one nonce, which will be invalidated the first time the Trader shim sees it.

# Changes
 - Only bump nonces on complete matchings
