### PR TITLE
Updated README_Contracts.md

### DIFF
--- a/contracts/README_Contracts.md
+++ b/contracts/README_Contracts.md
@@ -3,49 +3,37 @@
 
 
 
-    
-
 **GasOracle.sol**  
 **Explanation:** This contract is an implementation of an Oracle that reports a gas price estimate in $USD. The contract handles 1 such Oracle. The constructor requires the address of a $USD price oracle and gas price oracle but has the functionality to change what these oracles are.       
-**Inheritance:** This contract inherits from IOracle.sol   
 Usage: This contract is used in order to retrieve the current gas price in $USD
 
 **Oracle.sol**  
 **Explanation:** This contract is an implementation of an Oracle that reports the market price of the underlying asset that the tracers value is based upon. Implementations of these oracles can differ as long as the oracle complies with IOracle.sol and is community approve      
-**Inheritance**: This contract inherits from IOracle.sol 
 Usage: This contract is used in order to retrieve off chain asset prices (via Chainlink) as well as the Ethereum gas price
 
 **Gov.sol**  
 **Explanation:** This contract contains the logic for the governance of the system. It uses an IEC20 token (govToken), these tokens can be staked in order to facilitate voting and proposals. Staked tokens can be delegated.   
-**Inheritance:** Contract inherits from the IGov.sol interface. 
 Usage: This contract is used to facilitate the management of the entire system. It contains voting/proposal logic. 
 
 **Insurance.sol**     
 **Explanation:** An insurance contract handles the Insurance Pool token, withdrawing/staking into a specific tracer’s insurance pool and deploying insurance pools for new tracers.  
-**Inheritance:** The Insurance.sol contract inherits from the IInsurance.sol interface
 Usage: This contract is used to manage the insurance pools of tracers. 
 
 **Account.sol**   
 **Explanation:** The account contract handles functionality allowing users to deposit/withdraw from tracer margin accounts, settling of said Tracer accounts, handles liquidation events and updates accounts in accordance of these events.  
-**Inheritance:** The Account.sol contract inherits from the IAccount.sol interface. 
-
 
 **TracerFactory.sol**   
-**Explanation:** This contract absorbs valid Tracers and is used to validate if a tracer is in fact valid and accepted. Also has functionality to allow changing of the current deployment and insurance contracts  
-**Inheritance:** This contract inheritance from the ITraceFactory.sol interface
+**Explanation:** This contract deploys new Tracers and is used to validate if a tracer is DAO approved. It also sets up new insurance pools (using Insurance.sol), and initialising the Tracer.
 
 **Tracer.sol**   
-**Explanation:** The tracer contract handles the deployment  of tracer markets, creation and filling of market orders, settlement of accounts and updating the pricing values of the Tracer (via a pricing contract (e.g. Pricing.sol)). 
+**Explanation:** The tracer contract handles the creation and filling of market orders, settlement of accounts and updating the pricing values of the Tracer (via a pricing contract (e.g. Pricing.sol)). 
 The Tracer contract also contains governance functions that allows the contract owner to transfer ownership of a Tracer, change/set the pricing oracles and manipulate the fee system.   
-**Inheritance:** The Tracer.sol contract inherits from the ITracer interface
 
 **Pricing.sol**  
 **Explanation:** A Pricing contract handles all of the updating, storage allocation and retrieval of values related to the value of a Tracer (e.g. funding rate, Tracer price, timeValue/interestRates)  
-**Inheritance**: The Pricing.sol contract inherits from the IPricing.sol interface
 
 **Receipt.sol**   
 **Explanation:** The receipt contract handles the creation of liquidation receipts and retrieval  of funds entitled to entities who facilitate a complete and successful liquidation (via claiming of one such receipt)   
-**Inheritance:** The Receipt.sol contract inherits from the IReceipt.sol interface. 
 
 
 


### PR DESCRIPTION
### Motivation
`contracts/README_Contracts.md` was outdated, especially relating to TracerFactory.sol

### Changes
##### contracts/README_Contract.md:
- Removed the "Inheritance" subtitles, because I think they are basically redundant, since they're just saying "Account inherits the IAccount interface" etc.
- Changed Tracer.sol section, because Tracer.sol doesn't deploy tracer markets (the factory does)
- Changed TracerFactory.sol section, because it deploys Tracers, not absorbs them.