### PR TITLE
Clean up tracer

### DIFF
--- a/contracts/DeployerV1.sol
+++ b/contracts/DeployerV1.sol
@@ -20,7 +20,8 @@ contract DeployerV1 is IDeployer {
             address _accountContract,
             address _pricingContract,
             int256 _maxLeverage,
-            uint256 _fundingRateSensitivity
+            uint256 _fundingRateSensitivity,
+            uint256 _feeRate
         ) = abi.decode(_data, (
             bytes32,
             address,
@@ -29,6 +30,7 @@ contract DeployerV1 is IDeployer {
             address,
             address,
             int256,
+            uint256,
             uint256
         ));
         TracerPerpetualSwaps tracer = new TracerPerpetualSwaps(
@@ -39,7 +41,8 @@ contract DeployerV1 is IDeployer {
             _accountContract,
             _pricingContract,
             _maxLeverage,
-            _fundingRateSensitivity
+            _fundingRateSensitivity,
+            _feeRate
         );
         tracer.transferOwnership(msg.sender);
         return address(tracer);

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -24,11 +24,9 @@ interface ITracerPerpetualSwaps {
 
     function LIQUIDATION_GAS_COST() external view returns(uint256);
 
-    function FUNDING_RATE_SENSITIVITY() external view returns(uint256);
+    function fundingRateSensitivity() external view returns(uint256);
 
     function currentHour() external view returns(uint8);
-
-    function setUserPermissions(address account, bool permission) external;
 
     function setInsuranceContract(address insurance) external;
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -89,7 +89,7 @@ contract TracerPerpetualSwaps is
 		priceMultiplier = 10**uint256(ioracle.decimals());
 		feeRate = _feeRate;
 		maxLeverage = _maxLeverage;
-		fundingRateSensitivity = fundingRateSensitivity;
+		fundingRateSensitivity = _fundingRateSensitivity;
 
 		// Start average prices from deployment
 		startLastHour = block.timestamp;
@@ -194,16 +194,16 @@ contract TracerPerpetualSwaps is
 			"TCR: Order already filled "
 		);
 
+		// settle accounts
+		settle(order1.maker);
+		settle(order2.maker);
+
 		// update account states
 		executeTrade(order1, order2, fillAmount);
 
 		// update leverage
 		_updateAccountLeverage(order1.maker);
 		_updateAccountLeverage(order2.maker);
-
-		// settle accounts
-		settle(order1.maker);
-		settle(order2.maker);
 
 		// Update internal trade state
 		// note: price has already been validated here, so order 1 price can be used

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -76,7 +76,7 @@ contract TracerPerpetualSwaps is
 		address _pricingContract,
 		address _liquidationContract,
 		int256 _maxLeverage,
-		uint256 fundingRateSensitivity,
+		uint256 _fundingRateSensitivity,
 		uint256 _feeRate
 	) public Ownable() {
 		pricingContract = IPricing(_pricingContract);
@@ -126,7 +126,6 @@ contract TracerPerpetualSwaps is
 			marginIsValid(
 				newBase,
 				userBalance.quote,
-				pricingContract.fairPrices(address(this)),
 				userBalance.lastUpdatedGasPrice
 			),
 			"TCR: Withdraw below valid Margin "
@@ -543,7 +542,6 @@ contract TracerPerpetualSwaps is
 	 * @notice Checks the validity of a potential margin given the necessary parameters
 	 * @param base The base value to be assessed (positive or negative)
 	 * @param quote The accounts quote units
-	 * @param price The market price of the quote asset
 	 * @param gasPrice The gas price
 	 * @return a bool representing the validity of a margin
 	 */
@@ -596,10 +594,6 @@ contract TracerPerpetualSwaps is
 				accountBalance.lastUpdatedGasPrice
 			);
 	}
-
-	// --------------------- //
-	//  GOVERNANCE FUNCTIONS //
-	// --------------------- //
 
 	function setInsuranceContract(address insurance) public override onlyOwner {
 		insuranceContract = IInsurance(insurance);


### PR DESCRIPTION
# Motivation
As per #45 all account state has been migrated into the Tracer contract. This introduces opportunities to reduce the size of the codebase by removing redundant function calls, optimising pieces of code and just in general cleaning things up.

# Changes
- rename funding rate sensitivity as it isn't a constant
- remove user permissioning from the tracer (to become whitelisting of trading interfaces eventually)
- add fee rate as a constructor argument
- add todos for library functions
- general optimisations
- remove redundant use of the `market` parameter since the address of the tracer is now known in all contexts
- simplified state management on trade execution