### PR TITLE
Compilation fixes. Balances fetched from TracerPerpSwaps now

### DIFF
--- a/contracts/DeployerV1.sol
+++ b/contracts/DeployerV1.sol
@@ -17,7 +17,6 @@ contract DeployerV1 is IDeployer {
             address _tracerBaseToken,
             address _oracle,
             address _gasPriceOracle,
-            address _accountContract,
             address _pricingContract,
             address _liquidationContract,
             int256 _maxLeverage,
@@ -25,7 +24,6 @@ contract DeployerV1 is IDeployer {
             uint256 _feeRate
         ) = abi.decode(_data, (
             bytes32,
-            address,
             address,
             address,
             address,
@@ -40,7 +38,6 @@ contract DeployerV1 is IDeployer {
             _tracerBaseToken,
             _oracle,
             _gasPriceOracle,
-            _accountContract,
             _pricingContract,
             _liquidationContract,
             _maxLeverage,

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -38,6 +38,8 @@ interface ITracerPerpetualSwaps {
 
     function currentHour() external view returns(uint8);
 
+    function getBalance(address account) external view returns (Types.AccountBalance memory);
+
     function setInsuranceContract(address insurance) external;
 
     function setPricingContract(address pricing) external;

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -88,7 +88,7 @@ contract Pricing is IPricing {
         int256 timeValue = timeValues[market];
         (int256 underlyingTWAP, int256 deriativeTWAP) = getTWAPs(market, _tracer.currentHour());
         int256 newFundingRate = (deriativeTWAP - underlyingTWAP - timeValue) * 
-           (_tracer.FUNDING_RATE_SENSITIVITY().toInt256());
+           (_tracer.fundingRateSensitivity().toInt256());
         // set the index to the last funding Rate confirmed funding rate (-1)
         uint256 fundingIndex = currentFundingIndex[market] - 1;
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -329,7 +329,7 @@ contract TracerPerpetualSwaps is
 		int256 liquidateeBaseChange,
 		int256 liquidateeQuoteChange,
 		uint256 amountToEscrow
-	) external onlyLiquidation {
+	) external override onlyLiquidation {
 		// Limits the gas use when liquidating
 		int256 gasPrice = IOracle(gasPriceOracle).latestAnswer();
 		require(
@@ -594,6 +594,10 @@ contract TracerPerpetualSwaps is
 				accountBalance.lastUpdatedGasPrice
 			);
 	}
+
+    function getBalance(address account) public view override returns (Types.AccountBalance memory) {
+        return balances[account];
+    }
 
 	function setInsuranceContract(address insurance) public override onlyOwner {
 		insuranceContract = IInsurance(insurance);

--- a/contracts/lib/LibLiquidation.sol
+++ b/contracts/lib/LibLiquidation.sol
@@ -31,7 +31,7 @@ library LibLiquidation {
         if (amountToEscrow < 0) {
             return 0;
         }
-        return amountToEscrow;
+        return uint256(amountToEscrow);
     }
 
     /**


### PR DESCRIPTION
### Changes
- getBalance in TracerPerSwaps
- Lots of other compilation fixes
- Commented out calcUnitsSold because we need to reengineer it.