### PR TITLE
Move logic from Tracer to Pricing

### DIFF
--- a/contracts/DeployerV1.sol
+++ b/contracts/DeployerV1.sol
@@ -15,7 +15,6 @@ contract DeployerV1 is IDeployer {
         (
             bytes32 _tracerId,
             address _tracerBaseToken,
-            address _oracle,
             address _gasPriceOracle,
             address _pricingContract,
             address _liquidationContract,
@@ -28,7 +27,6 @@ contract DeployerV1 is IDeployer {
             address,
             address,
             address,
-            address,
             int256,
             uint256,
             uint256
@@ -36,7 +34,6 @@ contract DeployerV1 is IDeployer {
         TracerPerpetualSwaps tracer = new TracerPerpetualSwaps(
             _tracerId,
             _tracerBaseToken,
-            _oracle,
             _gasPriceOracle,
             _pricingContract,
             _liquidationContract,

--- a/contracts/DeployerV1.sol
+++ b/contracts/DeployerV1.sol
@@ -20,7 +20,8 @@ contract DeployerV1 is IDeployer {
             address _liquidationContract,
             int256 _maxLeverage,
             uint256 _fundingRateSensitivity,
-            uint256 _feeRate
+            uint256 _feeRate,
+            uint256 _oracleDecimals
         ) = abi.decode(_data, (
             bytes32,
             address,
@@ -28,6 +29,7 @@ contract DeployerV1 is IDeployer {
             address,
             address,
             int256,
+            uint256,
             uint256,
             uint256
         ));
@@ -39,7 +41,8 @@ contract DeployerV1 is IDeployer {
             _liquidationContract,
             _maxLeverage,
             _fundingRateSensitivity,
-            _feeRate
+            _feeRate,
+            _oracleDecimals
         );
         tracer.transferOwnership(msg.sender);
         return address(tracer);

--- a/contracts/Interfaces/IPricing.sol
+++ b/contracts/Interfaces/IPricing.sol
@@ -2,11 +2,6 @@
 pragma solidity ^0.8.0;
 
 interface IPricing {
-    function setFundingRate(int256 price, int256 fundingRate, int256 fundingRateValue) external;
-
-    function setInsuranceFundingRate(int256 price, int256 fundingRate, int256 fundingRateValue) external;
-
-    function incrementFundingIndex() external;
 
     function getFundingRate(uint index) external view returns(uint256, int256, int256, int256);
 
@@ -17,26 +12,10 @@ interface IPricing {
     function fairPrice() external view returns (int256);
 
     function timeValue() external view returns(int256);
-    
-    function updatePrice(
-        int256 price,
-        int256 oraclePrice,
-        bool newRecord
-    ) external;
-
-    function updateFundingRate(int256 oraclePrice, int256 poolFundingRate) external;
-
-    function updateTimeValue() external;
 
     function getTWAPs(uint currentHour)  external view returns (int256, int256);
         
     function get24HourPrices() external view returns (uint256, uint256);
-
-    function getOnlyFundingRate(uint index) external view returns (int256);
-
-    function getOnlyFundingRateValue(uint index) external view returns (int256);
-
-    function getOnlyInsuranceFundingRateValue(uint index) external view returns(int256);
 
     function getHourlyAvgTracerPrice(uint256 hour) external view returns (int256);
 

--- a/contracts/Interfaces/IPricing.sol
+++ b/contracts/Interfaces/IPricing.sol
@@ -41,4 +41,6 @@ interface IPricing {
     function getHourlyAvgTracerPrice(uint256 hour) external view returns (int256);
 
     function getHourlyAvgOraclePrice(uint256 hour) external view returns (int256);
+
+    function recordTrade(int256 tradePrice, uint256 tradeVolume) external;
 }

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -36,8 +36,6 @@ interface ITracerPerpetualSwaps {
 
     function fundingRateSensitivity() external view returns(uint256);
 
-    function currentHour() external view returns(uint8);
-
     function getBalance(address account) external view returns (Types.AccountBalance memory);
 
     function setInsuranceContract(address insurance) external;
@@ -55,8 +53,6 @@ interface ITracerPerpetualSwaps {
     function setFundingRateSensitivity(uint256 _fundingRateSensitivity) external;
 
     function transferOwnership(address newOwner) external;
-
-    function initializePricing() external;
 
     function matchOrders(Types.Order memory order1, Types.Order memory order2, uint256 fillAmount) external;
 }

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -22,8 +22,6 @@ interface ITracerPerpetualSwaps {
 
     function leveragedNotionalValue() external view returns(int256);
 
-    function oracle() external view returns(address);
-
     function gasPriceOracle() external view returns(address);
 
     function priceMultiplier() external view returns(uint256);
@@ -41,8 +39,6 @@ interface ITracerPerpetualSwaps {
     function setInsuranceContract(address insurance) external;
 
     function setPricingContract(address pricing) external;
-
-    function setOracle(address _oracle) external;
 
     function setGasOracle(address _gasOracle) external;
 

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -202,11 +202,7 @@ contract Pricing is IPricing {
      * @notice Given the address of a tracer market this function will get the current fair price for that market
      */
     function fairPrice() public view override returns (int256) {
-        // grab all necessary variable from helper functions
-        ITracerPerpetualSwaps _tracer = ITracerPerpetualSwaps(tracer);
-
-        int256 oraclePrice = IOracle(_tracer.oracle()).latestAnswer();
-
+        int256 oraclePrice = oracle.latestAnswer();
         // calculates fairPrice
         return oraclePrice - timeValue;
     }

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -76,7 +76,6 @@ contract Pricing is IPricing {
         uint256 tradeVolume
     ) external override onlyTracer {
         int256 currentOraclePrice = oracle.latestAnswer();
-        // todo the pricing should need the oracle, not the tracer market?
         if (startLastHour <= block.timestamp - 1 hours) {
             // emit the old hourly average
             int256 hourlyTracerPrice = getHourlyAvgTracerPrice(currentHour);

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -33,7 +33,6 @@ contract TracerPerpetualSwaps is
 	uint256 public override feeRate;
 
 	// Config variables
-	address public override oracle;
 	address public override gasPriceOracle;
 	int256 public override maxLeverage; // The maximum ratio of notionalValue to margin
 
@@ -52,14 +51,16 @@ contract TracerPerpetualSwaps is
 	 *         will be able to purchase and trade tracers after this deployment.
 	 * @param _marketId the id of the market, given as BASE/QUOTE
 	 * @param _tracerBaseToken the address of the token used for margin accounts (i.e. The margin token)
-	 * @param _oracle the address of the contract implementing the tracer oracle interface
 	 * @param _gasPriceOracle the address of the contract implementing gas price oracle
 	 * @param _pricingContract the address of the contract implementing the IPricing.sol interface
+	 * @param _liquidationContract the contract that manages liquidations for this market
+	 * @param _maxLeverage the max leverage of the market. Min margin is derived from this
+	 * @param _fundingRateSensitivity the affect funding rate changes have on funding paid.
+	 * @param _feeRate the fee to be taken on trades in this market
 	 */
 	constructor(
 		bytes32 _marketId,
 		address _tracerBaseToken,
-		address _oracle,
 		address _gasPriceOracle,
 		address _pricingContract,
 		address _liquidationContract,
@@ -70,11 +71,11 @@ contract TracerPerpetualSwaps is
 		pricingContract = IPricing(_pricingContract);
 		liquidationContract = _liquidationContract;
 		tracerBaseToken = _tracerBaseToken;
-		oracle = _oracle;
 		gasPriceOracle = _gasPriceOracle;
 		marketId = _marketId;
-		IOracle ioracle = IOracle(oracle);
-		priceMultiplier = 10**uint256(ioracle.decimals());
+		// todo pull oracle from insurance here
+		//priceMultiplier = 10**uint256(ioracle.decimals());
+		priceMultiplier = 10**8;
 		feeRate = _feeRate;
 		maxLeverage = _maxLeverage;
 		fundingRateSensitivity = _fundingRateSensitivity;
@@ -470,10 +471,6 @@ contract TracerPerpetualSwaps is
 
 	function setPricingContract(address pricing) public override onlyOwner {
 		pricingContract = IPricing(pricing);
-	}
-
-	function setOracle(address _oracle) public override onlyOwner {
-		oracle = _oracle;
 	}
 
 	function setGasOracle(address _gasOracle) public override onlyOwner {

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -23,10 +23,10 @@ contract TracerPerpetualSwaps is
 
 	uint256 public override fundingRateSensitivity;
 	uint256 public constant override LIQUIDATION_GAS_COST = 63516;
+	// todo ensure these are fine being immutable
 	uint256 public immutable override priceMultiplier;
 	address public immutable override tracerBaseToken;
 	bytes32 public immutable override marketId;
-	IAccount public accountContract;
 	IPricing public pricingContract;
 	IInsurance public insuranceContract;
 	address public liquidationContract;
@@ -66,16 +66,17 @@ contract TracerPerpetualSwaps is
 		address _liquidationContract,
 		int256 _maxLeverage,
 		uint256 _fundingRateSensitivity,
-		uint256 _feeRate
+		uint256 _feeRate,
+		uint256 _oracleDecimals
 	) public Ownable() {
 		pricingContract = IPricing(_pricingContract);
+		// dont convert to interface as we don't need to interact
+		// with the contract
 		liquidationContract = _liquidationContract;
 		tracerBaseToken = _tracerBaseToken;
 		gasPriceOracle = _gasPriceOracle;
 		marketId = _marketId;
-		// todo pull oracle from insurance here
-		//priceMultiplier = 10**uint256(ioracle.decimals());
-		priceMultiplier = 10**8;
+		priceMultiplier = 10**uint256(_oracleDecimals);
 		feeRate = _feeRate;
 		maxLeverage = _maxLeverage;
 		fundingRateSensitivity = _fundingRateSensitivity;

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -35,13 +35,7 @@ contract TracerPerpetualSwaps is
 	// Config variables
 	address public override oracle;
 	address public override gasPriceOracle;
-	bool private pricingInitialized;
 	int256 public override maxLeverage; // The maximum ratio of notionalValue to margin
-
-	// Funding rate variables
-	uint256 internal startLastHour;
-	uint256 internal startLast24Hours;
-	uint8 public override currentHour;
 
 	// Account State Variables
 	mapping(address => Types.AccountBalance) public balances;
@@ -49,12 +43,6 @@ contract TracerPerpetualSwaps is
 	int256 public override leveragedNotionalValue;
 
 	event FeeReceiverUpdated(address receiver);
-	event HourlyPriceUpdated(int256 price, uint256 currentHour);
-	event FundingRateUpdated(int256 fundingRate, int256 fundingRateValue);
-	event InsuranceFundingRateUpdated(
-		int256 insuranceFundingRate,
-		int256 insuranceFundingRateValue
-	);
 	event Deposit(address indexed user, uint256 indexed amount);
 	event Withdraw(address indexed user, uint256 indexed amount);
 	event Settled(address indexed account, int256 margin);
@@ -90,10 +78,6 @@ contract TracerPerpetualSwaps is
 		feeRate = _feeRate;
 		maxLeverage = _maxLeverage;
 		fundingRateSensitivity = _fundingRateSensitivity;
-
-		// Start average prices from deployment
-		startLastHour = block.timestamp;
-		startLast24Hours = block.timestamp;
 	}
 
 	/**
@@ -143,20 +127,6 @@ contract TracerPerpetualSwaps is
 		emit Withdraw(msg.sender, amount);
 	}
 
-	/**
-	 * @notice Sets the pricing constants initiallly in the pricing contract
-	 */
-	function initializePricing() public override onlyOwner {
-		require(!pricingInitialized, "TCR: Pricing already set ");
-		// Set first funding rates to 0 and current time
-		int256 oracleLatestPrice = IOracle(oracle).latestAnswer();
-		pricingContract.setFundingRate(oracleLatestPrice, 0, 0);
-		pricingContract.setInsuranceFundingRate(oracleLatestPrice, 0, 0);
-
-		pricingContract.incrementFundingIndex();
-		pricingInitialized = true;
-	}
-
 	// TODO: Once whitelisting of trading interfaces is implemented this should
 	// only be called by a whitelisted interface
 	/**
@@ -202,7 +172,7 @@ contract TracerPerpetualSwaps is
 
 		// Update internal trade state
 		// note: price has already been validated here, so order 1 price can be used
-		updateInternalRecords(order1.price);
+		pricingContract.recordTrade(order1.price, fillAmount);
 
 		// Ensures that you are in a position to take the trade
 		require(
@@ -433,67 +403,6 @@ contract TracerPerpetualSwaps is
 				.currentFundingIndex();
 			require(userMarginIsValid(account), "TCR: Target under-margined ");
 			emit Settled(account, accountBalance.base);
-		}
-	}
-
-	// todo most of this logic should be in pricing. Tracer should simply
-	// call pricing and let it handle if state needs to be updated
-	/**
-	 * @notice Updates the internal records for pricing, funding rate and interest
-	 * @param price The price to be used to update the internal records, this is the price that a trade occurred at
-	 *              (i.e. The price and order has been filled at)
-	 */
-	function updateInternalRecords(int256 price) internal {
-		IOracle ioracle = IOracle(oracle);
-		if (startLastHour <= block.timestamp - 1 hours) {
-			// emit the old hourly average
-			int256 hourlyTracerPrice =
-				pricingContract.getHourlyAvgTracerPrice(currentHour);
-			emit HourlyPriceUpdated(hourlyTracerPrice, currentHour);
-
-			// Update the price to a new entry and funding rate every hour
-			// Check current hour and loop around if need be
-			if (currentHour == 23) {
-				currentHour = 0;
-			} else {
-				currentHour = currentHour + 1;
-			}
-			// Update pricing and funding rate states
-			pricingContract.updatePrice(price, ioracle.latestAnswer(), true);
-			int256 poolFundingRate =
-				insuranceContract.getPoolFundingRate(address(this)).toInt256();
-
-			pricingContract.updateFundingRate(
-				ioracle.latestAnswer(),
-				poolFundingRate
-			);
-
-			// Gather variables and emit events
-			uint256 currentFundingIndex = pricingContract.currentFundingIndex();
-			(, , int256 fundingRate, int256 fundingRateValue) =
-				pricingContract.getFundingRate(currentFundingIndex);
-			(
-				,
-				,
-				int256 insuranceFundingRate,
-				int256 insuranceFundingRateValue
-			) = pricingContract.getInsuranceFundingRate(currentFundingIndex);
-			emit FundingRateUpdated(fundingRate, fundingRateValue);
-			emit InsuranceFundingRateUpdated(
-				insuranceFundingRate,
-				insuranceFundingRateValue
-			);
-
-			if (startLast24Hours <= block.timestamp - 24 hours) {
-				// Update the interest rate every 24 hours
-				pricingContract.updateTimeValue();
-				startLast24Hours = block.timestamp;
-			}
-
-			startLastHour = block.timestamp;
-		} else {
-			// Update old pricing entry
-			pricingContract.updatePrice(price, ioracle.latestAnswer(), false);
 		}
 	}
 

--- a/contracts/TracerPerpetualsFactory.sol
+++ b/contracts/TracerPerpetualsFactory.sol
@@ -74,7 +74,6 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
 
         // Perform admin operations on the tracer to finalise linking
         tracer.setInsuranceContract(insurance);
-        tracer.initializePricing();
 
         // Ownership either to the deployer or the DAO
         tracer.transferOwnership(tracerOwner);

--- a/contracts/mock/MockTracerPerpsFactory.sol
+++ b/contracts/mock/MockTracerPerpsFactory.sol
@@ -67,9 +67,6 @@ contract MockTracerPerpetualsFactory is ITracerPerpetualsFactory {
 
         tracerCounter++;
 
-        //Perform admin operations on the tracer to finalise linking
-        // tracer.setInsuranceContract(insurance);
-        tracer.initializePricing();
         emit TracerDeployed(marketId, market);
     }
 


### PR DESCRIPTION
# Motivation
As per the new design, the Tracer perp contract should only hold logic for actual updating of account state and trade execution. Currently it holds a lot of timing and pricing state, where it simply communicates between itself and pricing.

# Changes
- remove any timing state from Tracer and add to Pricing
- remove all cross communication except for the tracer notifying pricing of trade execution.
- removes the oracle from the tracer as it is not needed
- adds a constructor argument for oracle decimals to still support price multiplier (however this will probably be removed at some point too)
- formatting fixes