### PR TITLE
Chainlink oracle adapter

### DIFF
--- a/contracts/Interfaces/IOracle.sol
+++ b/contracts/Interfaces/IOracle.sol
@@ -8,7 +8,5 @@ interface IOracle {
     function isStale() external view returns (bool);
 
     function decimals() external view returns (uint8);
-
-    function setDecimals(uint8 _decimals) external;
 }
 

--- a/contracts/oracle/ChainlinkOracleAdapter.sol
+++ b/contracts/oracle/ChainlinkOracleAdapter.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "../Interfaces/IOracle.sol";
+import "../lib/LibMath.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * The Chainlink oracle adapter allows you to wrap a Chainlink oracle feed
+ * and ensure that the price is always returned in a wad format. 
+ * The upstream feed may be changed (Eg updated to a new Chainlink feed) while
+ * keeping price consistency for the actual Tracer perp market.
+ */
+contract OracleAdapter is IOracle, Ownable {
+    using LibMath for uint256;
+    IOracle public oracle;
+    uint256 private constant MAX_DECIMALS = 18;
+    int256 public scaler;
+
+    constructor(address _oracle) {
+        oracle = IOracle(_oracle);
+        // scaler can be used to keep all feed responses in units of 10^18
+        scaler = int256(10**(MAX_DECIMALS - oracle.decimals()));
+    }
+
+    /**
+     * @notice Gets the latest anwser from the oracle
+     * @dev converts the price to a WAD price before returning
+     */
+    function latestAnswer() external override view returns (int256) {
+        return toWad(oracle.latestAnswer());
+    }
+
+    function isStale() external override view returns (bool) {
+        return oracle.isStale();
+    }
+
+    function decimals() external override pure returns(uint8) {
+        return uint8(MAX_DECIMALS);
+    }
+
+    /**
+    * @notice converts a raw value to a WAD value.
+    * @dev this allows consistency for oracles used throughout the protocol
+    *      and allows oracles to have their decimals changed withou affecting
+    *      the market itself
+    */
+    function toWad(int256 raw) internal view returns(int256) {
+        return raw * scaler;
+    }
+
+    /**
+    * @notice Change the upstream feed address.
+    * @dev resets the scalar value to ensure WAD values are always returned 
+    */
+    function changeUpstreamOracle(address newOracle) external onlyOwner {
+        oracle = IOracle(newOracle);
+        // reset the scaler for consistency
+        scaler = int256(10**(MAX_DECIMALS - oracle.decimals()));
+    }
+}

--- a/contracts/oracle/ChainlinkOracleAdapter.sol
+++ b/contracts/oracle/ChainlinkOracleAdapter.sol
@@ -18,9 +18,7 @@ contract OracleAdapter is IOracle, Ownable {
     int256 public scaler;
 
     constructor(address _oracle) {
-        oracle = IOracle(_oracle);
-        // scaler can be used to keep all feed responses in units of 10^18
-        scaler = int256(10**(MAX_DECIMALS - oracle.decimals()));
+        setOracle(_oracle);
     }
 
     /**
@@ -51,11 +49,20 @@ contract OracleAdapter is IOracle, Ownable {
 
     /**
     * @notice Change the upstream feed address.
+    */
+    function changeOracle(address newOracle) public onlyOwner {
+        setOracle(newOracle);
+    }
+
+    /**
+    * @notice sets the upstream oracle
     * @dev resets the scalar value to ensure WAD values are always returned 
     */
-    function changeUpstreamOracle(address newOracle) external onlyOwner {
+    function setOracle(address newOracle) internal {
         oracle = IOracle(newOracle);
         // reset the scaler for consistency
-        scaler = int256(10**(MAX_DECIMALS - oracle.decimals()));
+        uint8 _decimals = oracle.decimals();
+        require(_decimals <= MAX_DECIMALS, "COA: too many decimals");
+        scaler = int256(10**(MAX_DECIMALS - _decimals));        
     }
 }

--- a/contracts/oracle/GasOracle.sol
+++ b/contracts/oracle/GasOracle.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import "./Interfaces/IOracle.sol";
-import "./lib/LibMath.sol";
+import "../Interfaces/IOracle.sol";
+import "../lib/LibMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
@@ -17,7 +17,7 @@ contract GasOracle is IOracle, Ownable {
     int256 public usdToGas;
     uint8 public override decimals = 8; // default of 8 decimals for USD price feeds in the Chainlink ecosystem
 
-    constructor(address _priceOracle, address _gasOracle) public {
+    constructor(address _priceOracle, address _gasOracle) {
         gasOracle = IOracle(_gasOracle); /* Gas cost oracle */
         priceOracle = IOracle(_priceOracle); /* Base/ETH oracle */
     }
@@ -41,8 +41,11 @@ contract GasOracle is IOracle, Ownable {
         return (gasOracle.latestAnswer() * priceOracle.latestAnswer()) / divisionPower.toInt256();
     }
 
+    /**
+    * @notice returns if either feed is stale
+    */
     function isStale() external override view returns (bool) {
-        return false;
+        return (gasOracle.isStale() || priceOracle.isStale());
     }
 
     /**
@@ -60,7 +63,7 @@ contract GasOracle is IOracle, Ownable {
         priceOracle = IOracle(_priceOracle);
     }
 
-    function setDecimals(uint8 _decimals) external override {
+    function setDecimals(uint8 _decimals) external {
         decimals = _decimals;
     }
 }

--- a/contracts/oracle/Oracle.sol
+++ b/contracts/oracle/Oracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import "./Interfaces/IOracle.sol";
+import "../Interfaces/IOracle.sol";
 
 /**
  * @dev The following is a sample Oracle Implementation for a Tracer Oracle.
@@ -27,7 +27,7 @@ contract Oracle is IOracle {
         price = _price;
     }
 
-    function setDecimals(uint8 _decimals) external override {
+    function setDecimals(uint8 _decimals) external {
         decimals = _decimals;
     }
 }


### PR DESCRIPTION
# Motivation
In order to keep consistency across markets, an oracle adapter has been added that converts all prices reported by the oracle to a WAD format. This also means that the oracle feed can be changed without stopping and migrating the market, as an oracle using a new decimal format can be used, and this adapter will still return the WAD formatted price

# Changes
- move oracles to their own folder
- create `ChainlinkOracleAdapter.sol`
- remove redundant function from oracles
- fix the gas oracle `isStale` function to actually return the results from the upstream oracle