### PR TITLE
Move Insurance state

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -51,7 +51,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
         collateralToken.transferFrom(msg.sender, address(this), amount);
         
         // Update pool balances and user
-        this.updatePoolAmount();
+        updatePoolAmount();
         InsurancePoolToken poolToken = InsurancePoolToken(token);
         uint256 tokensToMint;
         
@@ -80,7 +80,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     function withdraw(uint256 amount) external override {
         require(amount > 0, "INS: amount <= 0");
 
-        this.updatePoolAmount();
+        updatePoolAmount();
         uint256 balance = getPoolUserBalance(msg.sender);
         require(balance >= amount, "INS: balance < amount");
 
@@ -107,7 +107,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
      * @notice Internally updates a given tracer's pool amount according to the tracer contract
      * @dev Withdraws from tracer, and adds amount to the pool's amount field. 
      */
-    function updatePoolAmount() external override {
+    function updatePoolAmount() public override {
         int256 base = (tracer.getBalance(address(this))).base;
         if (base > 0) {
             tracer.withdraw(uint(base));

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -51,6 +51,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
         collateralToken.transferFrom(msg.sender, address(this), amount);
         
         // Update pool balances and user
+        this.updatePoolAmount();
         InsurancePoolToken poolToken = InsurancePoolToken(token);
         uint256 tokensToMint;
         
@@ -79,6 +80,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     function withdraw(uint256 amount) external override {
         require(amount > 0, "INS: amount <= 0");
 
+        this.updatePoolAmount();
         uint256 balance = getPoolUserBalance(msg.sender);
         require(balance >= amount, "INS: balance < amount");
 
@@ -102,8 +104,8 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
 
 
     /**
-     * @notice Internally updates a given tracer's pool amount according to the Account contract
-     * @dev Withdraws from tracer in account, and adds amount to the pool's amount field
+     * @notice Internally updates a given tracer's pool amount according to the tracer contract
+     * @dev Withdraws from tracer, and adds amount to the pool's amount field. 
      */
     function updatePoolAmount() external override {
         int256 base = (tracer.getBalance(address(this))).base;
@@ -114,7 +116,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     }
 
     /**
-     * @notice Deposits some of the insurance pool's amount into the account contract
+     * @notice Deposits some of the insurance pool's amount into the tracer contract
      * @dev If amount is greater than the insurance pool's balance, deposit total balance.
      *      This was done because in such an emergency situation, we want to recover as much as possible
      * @param amount The desired amount to take from the insurance pool

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "./Interfaces/ITracerPerpetualSwaps.sol";
-import "./Interfaces/IAccount.sol";
 import "./Interfaces/IInsurance.sol";
 import "./Interfaces/ITracerPerpetualsFactory.sol";
 import "./InsurancePoolToken.sol";
@@ -15,107 +14,101 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     using LibMath for uint256;
     using LibMath for int256;
 
-    int256 public override constant INSURANCE_MUL_FACTOR = 1000000000;
+    int256 public constant override INSURANCE_MUL_FACTOR = 1000000000;
     uint256 public constant SAFE_TOKEN_MULTIPLY = 1e18;
-    address public immutable TCRTokenAddress;
-    IAccount public account;
     ITracerPerpetualsFactory public perpsFactory;
 
-    struct StakePool { 
-        address market;
-        address collateralAsset;
-        uint256 amount; // amount of underlying collateral in pool
-        address token; // tokenized holdings of pool - not necessarily 1 to 1 with underlying
-        mapping(address => uint256) userDebt; // record of user debt to the pool
-        mapping(address => uint256) lastRewardsUpdate;
-    }
+    address public collateralAsset; // Address of collateral asset
+    uint256 public poolAmount; // amount of underlying collateral in pool
+    address public token; // tokenized holdings of pool - not necessarily 1 to 1 with underlying
 
-    // Tracer market => supported or not supported
-    mapping(address => bool) internal supportedTracers;
-    // Tracer market => StakePool
-    mapping(address => StakePool) internal pools;
+    ITracerPerpetualSwaps public tracer; // Tracer associated with Insurance Pool
 
     event InsuranceDeposit(address indexed market, address indexed user, uint256 indexed amount);
     event InsuranceWithdraw(address indexed market, address indexed user, uint256 indexed amount);
     event InsurancePoolDeployed(address indexed market, address indexed asset);
-    event InsurancePoolRewarded(address indexed market, uint256 indexed amount);
 
-    constructor(address TCR) public {
-        TCRTokenAddress = TCR;
+    constructor(address _tracer) {
+        require(perpsFactory.validTracers(_tracer), "Pool not deployed by perpsFactory");
+ 
+        tracer = ITracerPerpetualSwaps(_tracer);
+        InsurancePoolToken _token = new InsurancePoolToken("Tracer Pool Token", "TPT");
+        token = address(_token);
+        collateralAsset = tracer.tracerBaseToken();
+        poolAmount = 0;
+
+        // emit InsurancePoolDeployed(_tracer, tracer.tracerBaseToken());
     }
 
     /**
      * @notice Allows a user to stake to a given tracer market insurance pool
      * @dev Mints amount of the pool token to the user
      * @param amount the amount of tokens to stake
-     * @param market the address of the tracer market to provide insurance
      */
-    function stake(uint256 amount, address market) external override {
-        StakePool storage pool = pools[market];
-        IERC20 token = IERC20(pool.collateralAsset);
-        require(supportedTracers[market], "INS: Tracer not supported");
+    function stake(uint256 amount) external override {
+        require(perpsFactory.validTracers(address(tracer)), "Pool not deployed by perpsFactory");
 
-        token.transferFrom(msg.sender, address(this), amount);
+        IERC20 collateralToken = IERC20(collateralAsset);
+        collateralToken.transferFrom(msg.sender, address(this), amount);
         // Update pool balances and user
-        InsurancePoolToken poolToken = InsurancePoolToken(pool.token);
+        InsurancePoolToken poolToken = InsurancePoolToken(token);
         uint256 tokensToMint;
         if (poolToken.totalSupply() == 0) {
             // Mint at 1:1 ratio if no users in the pool
             tokensToMint = amount;
         } else {
             // Mint at the correct ratio =
-            //          Pool tokens (the ones to be minted) / pool.amount (the collateral asset)
+            //          Pool tokens (the ones to be minted) / poolAmount (the collateral asset)
             // Note the difference between this and withdraw. Here we are calculating the amount of tokens
             // to mint, and `amount` is the amount to deposit.
-            uint256 tokensToCollatRatio = (poolToken.totalSupply() * SAFE_TOKEN_MULTIPLY) / pool.amount;
+            uint256 tokensToCollatRatio = (poolToken.totalSupply() * SAFE_TOKEN_MULTIPLY) / poolAmount;
             tokensToMint = (tokensToCollatRatio * amount) / SAFE_TOKEN_MULTIPLY;
         }
         // Margin tokens become pool tokens
         poolToken.mint(msg.sender, tokensToMint);
-        pool.amount = pool.amount + amount;
-        emit InsuranceDeposit(market, msg.sender, amount);
+        poolAmount = poolAmount + amount;
+        emit InsuranceDeposit(address(tracer), msg.sender, amount);
     }
 
     /**
      * @notice Allows a user to withdraw their assets from a given insurance pool
      * @dev burns amount of tokens from the pool token
      * @param amount the amount of pool tokens to burn
-     * @param market the tracer contract that the insurance pool is for.
      */
-    function withdraw(uint256 amount, address market) external override {
+    function withdraw(uint256 amount) external override {
         require(amount > 0, "INS: amount <= 0");
-        uint256 balance = getPoolUserBalance(market, msg.sender);
+
+        uint256 balance = getPoolUserBalance(msg.sender);
         require(balance >= amount, "INS: balance < amount");
+
+        IERC20 collateralToken = IERC20(collateralAsset);
         // Burn tokens and pay out user
-        StakePool storage pool = pools[market];
-        IERC20 token = IERC20(pool.collateralAsset);
-        InsurancePoolToken poolToken = InsurancePoolToken(pool.token);
+        InsurancePoolToken poolToken = InsurancePoolToken(token);
 
         // Burn at the correct ratio =
-        //             pool.amount (collateral asset) / pool tokens
+        //             poolAmount (collateral asset) / pool tokens
         // Note the difference between this and stake. Here we are calculating the amount of tokens
         // to withdraw, and `amount` is the amount to burn.
-        uint256 collatToTokensRatio = (pool.amount * SAFE_TOKEN_MULTIPLY) / poolToken.totalSupply();
+        uint256 collatToTokensRatio = (poolAmount * SAFE_TOKEN_MULTIPLY) / poolToken.totalSupply();
         uint256 tokensToSend = (collatToTokensRatio * amount) / SAFE_TOKEN_MULTIPLY;
 
         // Pool tokens become margin tokens
         poolToken.burnFrom(msg.sender, amount);
-        token.transfer(msg.sender, tokensToSend);
-        pool.amount = pool.amount - tokensToSend;
-        emit InsuranceWithdraw(market, msg.sender, tokensToSend);
+        collateralToken.transfer(msg.sender, tokensToSend);
+        poolAmount = poolAmount - tokensToSend;
+        emit InsuranceWithdraw(address(tracer), msg.sender, tokensToSend);
     }
 
 
     /**
      * @notice Internally updates a given tracer's pool amount according to the Account contract
      * @dev Withdraws from tracer in account, and adds amount to the pool's amount field
-     * @param market the tracer contract that the insurance pool is for.
      */
-    function updatePoolAmount(address market) external override {
-        (int256 base, , , , ) = account.getBalance(address(this), market);
+    function updatePoolAmount() external override {
+        int256 base = (tracer.getBalance(address(this))).base;
         if (base > 0) {
-            account.withdraw(uint(base), market);
-            pools[market].amount = pools[market].amount + uint(base);
+            tracer.withdraw(uint(base));
+            poolAmount = poolAmount + uint(base);
         }
     }
 
@@ -123,14 +116,10 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
      * @notice Deposits some of the insurance pool's amount into the account contract
      * @dev If amount is greater than the insurance pool's balance, deposit total balance.
      *      This was done because in such an emergency situation, we want to recover as much as possible
-     * @param market The Tracer market whose insurance pool will be drained
      * @param amount The desired amount to take from the insurance pool
      */
-    function drainPool(address market, uint256 amount) external override onlyAccount() {
-        ITracerPerpetualSwaps _tracer = ITracerPerpetualSwaps(market);
-
-        uint256 poolAmount = pools[market].amount;
-        IERC20 tracerMarginToken = IERC20(_tracer.tracerBaseToken());
+    function drainPool(uint256 amount) external override onlyLiquidation() {
+        IERC20 tracerMarginToken = IERC20(tracer.tracerBaseToken());
 
         // Enforce a minimum. Very rare as funding rate will be incredibly high at this point
         if (poolAmount < 10 ** 18) {
@@ -152,57 +141,31 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
             difference = poolAmount - amount;
         }
 
-        tracerMarginToken.approve(address(account), amount);
-        account.deposit(amount, market);
-        pools[market].amount = difference;
-    }
-
-    /**
-     * @notice Adds a new tracer market to be insured.
-     * @dev Creates a new InsurancePoolToken and StakePool, adding them to pools and setting
-     *      this tracer to be supported
-     * @param market the address of the new tracer market
-     */
-    function deployInsurancePool(address market) external override {
-        require(!supportedTracers[market], "INS: pool already exists");
-        require(perpsFactory.validTracers(market), "INS: pool not deployed by perpsFactory");
-        ITracerPerpetualSwaps _tracer = ITracerPerpetualSwaps(market);
-        // Deploy token for the pool
-        InsurancePoolToken token = new InsurancePoolToken("Tracer Pool Token", "TPT");
-        StakePool storage pool = pools[market];
-        pool.market = market;
-        pool.collateralAsset = _tracer.tracerBaseToken();
-        pool.amount = 0;
-        pool.token = address(token);
-        supportedTracers[market] = true;
-        emit InsurancePoolDeployed(market, _tracer.tracerBaseToken());
+        tracerMarginToken.approve(address(tracer), amount);
+        tracer.deposit(amount);
+        poolAmount = difference;
     }
 
     /**
      * @notice gets a users balance in a given insurance pool
-     * @param market the market of the insurance pool to get the balance for
      * @param user the user whose balance is being retrieved
      */
-    function getPoolUserBalance(address market, address user) public override view returns (uint256) {
-        require (supportedTracers[market], "INS: Market not supported");
-        return InsurancePoolToken(pools[market].token).balanceOf(user);
+    function getPoolUserBalance(address user) public override view returns (uint256) {
+        return InsurancePoolToken(token).balanceOf(user);
     }
 
     /**
      * @notice Gets the token address representing pool ownership for a given pool
-     * @param market the market of the insurance pool to get the pool token for
      */
-    function getPoolToken(address market) external override view returns (address) {
-        return pools[market].token;
+    function getPoolToken() external override view returns (address) {
+        return token;
     }
 
     /**
      * @notice Gets the target fund amount for a given insurance pool
      * @dev The target amount is 1% of the leveraged notional value of the tracer being insured.
-     * @param market the market of the insurance pool to get the target for.
      */
-    function getPoolTarget(address market) public override view returns (uint256) {
-        ITracerPerpetualSwaps tracer = ITracerPerpetualSwaps(pools[market].market);
+    function getPoolTarget() public override view returns (uint256) {
         int256 target = tracer.leveragedNotionalValue() / 100;
 
         if (target > 0) {
@@ -213,30 +176,18 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     }
 
     /**
-     * @notice Gets the total holdings of collateral for a given insurance pool
-     * @param market the market of the insurance pool to get the holdings of.
-     */
-    function getPoolHoldings(address market) public override view returns (uint256) {
-        return pools[market].amount;
-    }
-
-    /**
      * @notice Gets the 8 hour funding rate for an insurance pool
      * @dev the funding rate is represented as 0.0036523 * (insurance_fund_target - insurance_fund_holdings) / leveraged_notional_value)
      *      To preserve precision, the rate is multiplied by 10^7.
-
-     * @param market the market of the insurance pool to get the funding rate of.
      */
-    function getPoolFundingRate(address market) external override view returns (uint256) {
-        ITracerPerpetualSwaps _tracer = ITracerPerpetualSwaps(market);
-
+    function getPoolFundingRate() external override view returns (uint256) {
         uint256 multiplyFactor = 3652300;
-        int256 levNotionalValue = _tracer.leveragedNotionalValue();
+        int256 levNotionalValue = tracer.leveragedNotionalValue();
         if (levNotionalValue <= 0) {
             return 0;
         }
 
-        int256 rate = ((multiplyFactor * (getPoolTarget(market) - getPoolHoldings(market))).toInt256()) / levNotionalValue;
+        int256 rate = ((multiplyFactor * (getPoolTarget() - poolAmount)).toInt256()) / levNotionalValue;
         if (rate < 0) {
             return 0;
         } else {
@@ -246,18 +197,9 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
 
     /**
      * @notice returns if the insurance pool needs funding or not
-     * @param market the tracer market address
      */
-    function poolNeedsFunding(address market) external override view returns (bool) {
-        return getPoolTarget(market) > pools[market].amount;
-    }
-
-    /**
-     * @notice returns if a tracer market is currently insured.
-     * @param market the tracer market address
-     */
-    function isInsured(address market) external override view returns (bool) {
-        return supportedTracers[market];
+    function poolNeedsFunding() external override view returns (bool) {
+        return getPoolTarget() > poolAmount;
     }
 
     /**
@@ -268,19 +210,11 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
         perpsFactory = ITracerPerpetualsFactory(_perpsFactory);
     }
 
-    /**
-     * @notice sets the address of the account contract (Account.sol)
-     * @param accountContract the new address of the accountContract
-     */
-    function setAccountContract(address accountContract) external override onlyOwner {
-        account = IAccount(accountContract);
-    }
-
-    /**
-     * @notice Checks if msg.sender is the account contract
-     */
-    modifier onlyAccount() {
-        require(msg.sender == address(account), "INS: sender is not account");
-        _;
-    }
+    modifier onlyLiquidation() {
+		require(
+			msg.sender == tracer.liquidationContract(),
+			"TCR: Sender not liquidation contract"
+		);
+		_;
+	}
 }

--- a/contracts/InsurancePoolToken.sol
+++ b/contracts/InsurancePoolToken.sol
@@ -8,7 +8,7 @@ contract InsurancePoolToken is ERC20, Ownable, ERC20Burnable {
     constructor(
         string memory name,
         string memory symbol
-    ) public ERC20(name, symbol) {
+    ) ERC20(name, symbol) {
     }
 
     function mint(address to, uint256 amount) external onlyOwner() {

--- a/contracts/Interfaces/IInsurance.sol
+++ b/contracts/Interfaces/IInsurance.sol
@@ -13,15 +13,11 @@ interface IInsurance {
 
     function getPoolUserBalance(address user) external view returns (uint256);
 
-    function getPoolToken() external view returns (address);
-
     function getPoolTarget() external view returns (uint256);
 
     function getPoolFundingRate() external view returns (uint256);
 
     function poolNeedsFunding() external view returns (bool);
-
-    function setFactory(address perpsFactory) external;
 
     function INSURANCE_MUL_FACTOR() external view returns (int256);
     

--- a/contracts/Interfaces/IInsurance.sol
+++ b/contracts/Interfaces/IInsurance.sol
@@ -3,33 +3,25 @@ pragma solidity ^0.8.0;
 
 interface IInsurance {
 
-    function stake(uint256 amount, address market) external;
+    function stake(uint256 amount) external;
 
-    function withdraw(uint256 amount, address market) external;
+    function withdraw(uint256 amount) external;
 
-    function updatePoolAmount(address market) external;
+    function updatePoolAmount() external;
 
-    function drainPool(address market, uint256 amount) external;
+    function drainPool(uint256 amount) external;
 
-    function deployInsurancePool(address market) external;
+    function getPoolUserBalance(address user) external view returns (uint256);
 
-    function getPoolUserBalance(address market, address user) external view returns (uint256);
+    function getPoolToken() external view returns (address);
 
-    function getPoolToken(address market) external view returns (address);
+    function getPoolTarget() external view returns (uint256);
 
-    function getPoolTarget(address market) external view returns (uint256);
+    function getPoolFundingRate() external view returns (uint256);
 
-    function getPoolHoldings(address market) external view returns (uint256);
-
-    function getPoolFundingRate(address market) external view returns (uint256);
-
-    function poolNeedsFunding(address market) external view returns (bool);
-
-    function isInsured(address market) external view returns (bool);
+    function poolNeedsFunding() external view returns (bool);
 
     function setFactory(address perpsFactory) external;
-
-    function setAccountContract(address accountContract) external;
 
     function INSURANCE_MUL_FACTOR() external view returns (int256);
     

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -18,6 +18,8 @@ interface ITracerPerpetualSwaps {
 
     function tracerBaseToken() external view returns (address);
 
+    function liquidationContract() external view returns (address);
+
     function marketId() external view returns(bytes32);
 
     function leveragedNotionalValue() external view returns(int256);
@@ -57,6 +59,10 @@ interface ITracerPerpetualSwaps {
     function transferOwnership(address newOwner) external;
 
     function initializePricing() external;
+
+    function deposit(uint256 amount) external;
+
+    function withdraw(uint256 amount) external;
 
     function matchOrders(Types.Order memory order1, Types.Order memory order2, uint256 fillAmount) external;
 }

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -29,7 +29,7 @@ contract TracerPerpetualSwaps is
 	IAccount public accountContract;
 	IPricing public pricingContract;
 	IInsurance public insuranceContract;
-	address public liquidationContract;
+	address public override liquidationContract;
 	uint256 public override feeRate;
 
 	// Config variables
@@ -101,7 +101,7 @@ contract TracerPerpetualSwaps is
 	 * @dev this contract must be an approvexd spender of the markets base token on behalf of the depositer.
 	 * @param amount The amount of base tokens to be deposited into the Tracer Market account
 	 */
-	function deposit(uint256 amount) external {
+	function deposit(uint256 amount) external override {
 		Types.AccountBalance storage userBalance = balances[msg.sender];
 		IERC20(tracerBaseToken).transferFrom(msg.sender, address(this), amount);
 
@@ -119,7 +119,7 @@ contract TracerPerpetualSwaps is
 	 * @dev Ensures that the users margin percent is valid after withdraw
 	 * @param amount The amount of margin tokens to be withdrawn from the tracer market account
 	 */
-	function withdraw(uint256 amount) external {
+	function withdraw(uint256 amount) external override {
 		Types.AccountBalance storage userBalance = balances[msg.sender];
 		int256 newBase = userBalance.base - amount.toInt256();
 		require(
@@ -461,7 +461,7 @@ contract TracerPerpetualSwaps is
 			// Update pricing and funding rate states
 			pricingContract.updatePrice(price, ioracle.latestAnswer(), true);
 			int256 poolFundingRate =
-				insuranceContract.getPoolFundingRate(address(this)).toInt256();
+				insuranceContract.getPoolFundingRate().toInt256();
 
 			pricingContract.updateFundingRate(
 				ioracle.latestAnswer(),

--- a/contracts/TracerPerpetualsFactory.sol
+++ b/contracts/TracerPerpetualsFactory.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.0;
 
 import "./Interfaces/ITracerPerpetualSwaps.sol";
-import "./Interfaces/IInsurance.sol";
 import "./Interfaces/ITracerPerpetualsFactory.sol";
 import "./Interfaces/IDeployer.sol";
+import "./Insurance.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
@@ -68,8 +68,9 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
 
         validTracers[market] = true;
         tracersByIndex[tracerCounter] = market;
-
-        IInsurance(insurance).deployInsurancePool(market);
+        
+        // Instantiate Insurance contract for tracer
+        insurance = address(new Insurance(address(market)));
         tracerCounter++;
 
         // Perform admin operations on the tracer to finalise linking

--- a/contracts/TracerPerpetualsFactory.sol
+++ b/contracts/TracerPerpetualsFactory.sol
@@ -70,7 +70,7 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
         tracersByIndex[tracerCounter] = market;
         
         // Instantiate Insurance contract for tracer
-        insurance = address(new Insurance(address(market)));
+        insurance = address(new Insurance(address(market), address(this)));
         tracerCounter++;
 
         // Perform admin operations on the tracer to finalise linking


### PR DESCRIPTION
# Motivation

The insurance contract is being made such that it is individual for each tracer -- meaning that there isn't one insurance contract that holds the insurance state for all tracers. 

# Changes

- Decouple insurance contracts from all tracers; each tracer now has an insurance contract of its own

- Change account instances to support the new TracerPerpetualSwaps contract

- Instantiate insurance contracts in deployer

- Add deposit & withdraw to perpetual swaps interface so that the insurance contract can call it