### PR TITLE
Remove ABI Encoder v2

### DIFF
--- a/contracts/Gov.sol
+++ b/contracts/Gov.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./Interfaces/IGov.sol";

--- a/contracts/Interfaces/IAccount.sol
+++ b/contracts/Interfaces/IAccount.sol
@@ -1,6 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 import "./Types.sol";
 
 interface IAccount {

--- a/contracts/Interfaces/IGov.sol
+++ b/contracts/Interfaces/IGov.sol
@@ -1,6 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 interface IGov {
     function stake(uint96 amount) external;

--- a/contracts/Interfaces/ILiquidation.sol
+++ b/contracts/Interfaces/ILiquidation.sol
@@ -1,6 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 import "./Types.sol";
 
 interface ILiquidation {

--- a/contracts/Interfaces/ISafetyWithdraw.sol
+++ b/contracts/Interfaces/ISafetyWithdraw.sol
@@ -1,6 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 interface ISafetyWithdraw {
     function withdrawERC20Token(address tokenAddress, address to, uint256 amount) external;

--- a/contracts/Interfaces/Types.sol
+++ b/contracts/Interfaces/Types.sol
@@ -1,6 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 interface Types {
 

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./lib/LibMath.sol";
 import "./lib/LibLiquidation.sol";

--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import './Interfaces/ITracerPerpetualSwaps.sol';
 import './Interfaces/IDex.sol';

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma experimental ABIEncoderV2;
 pragma solidity ^0.8.0;
 
 import "./LibMath.sol";

--- a/contracts/lib/LibLiquidation.sol
+++ b/contracts/lib/LibLiquidation.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma experimental ABIEncoderV2;
 pragma solidity ^0.8.0;
 
 import "./LibMath.sol";


### PR DESCRIPTION
# Motivation
As part of Solidity 0.8, ABI Encoder V2 is enabled by default (https://docs.soliditylang.org/en/v0.8.0/080-breaking-changes.html).

# Changes
- removes all references to abi encoder v2