### PR TITLE
getLiquidationReceipt now returns a struct

### DIFF
--- a/contracts/Interfaces/ILiquidation.sol
+++ b/contracts/Interfaces/ILiquidation.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 import "./Types.sol";
+import "../lib/LibLiquidation.sol";
 
 interface ILiquidation {
 
@@ -23,19 +24,7 @@ interface ILiquidation {
     function getLiquidationReceipt(uint256 id)
         external
         view
-        returns (
-            address,
-            address,
-            address,
-            int256,
-            uint256,
-            uint256,
-            uint256,
-            int256,
-            bool,
-            bool,
-            bool
-        );
+        returns (LibLiquidation.LiquidationReceipt memory);
 
     function liquidate(
         int256 amount, 

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -205,34 +205,9 @@ contract Liquidation is ILiquidation, Ownable {
         external
         override
         view
-        returns (
-            address,
-            address,
-            address,
-            int256,
-            uint256,
-            uint256,
-            uint256,
-            int256,
-            bool,
-            bool,
-            bool
-        )
+        returns (LibLiquidation.LiquidationReceipt memory)
     {
-        LibLiquidation.LiquidationReceipt memory _receipt = liquidationReceipts[id];
-        return (
-            _receipt.tracer,
-            _receipt.liquidator,
-            _receipt.liquidatee,
-            _receipt.price,
-            _receipt.time,
-            _receipt.escrowedAmount,
-            _receipt.releaseTime,
-            _receipt.amountLiquidated,
-            _receipt.escrowClaimed,
-            _receipt.liquidationSide,
-            _receipt.liquidatorRefundClaimed
-        );
+        return liquidationReceipts[id];
     }
 
 


### PR DESCRIPTION
### Motivation
Instead of returning every single variable from a struct, we can just return the struct.

### Changes
- `Liquidation.getLiquidationReceipt` now returns a struct
