### PR TITLE
Collateral library

### DIFF
--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -27,6 +27,8 @@ interface ITracerPerpetualSwaps {
 
     function tracerBaseToken() external view returns (address);
 
+    function baseTokenDecimals() external view returns (uint256);
+
     function liquidationContract() external view returns (address);
     
     function tradingWhitelist(address trader) external returns (bool);

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -95,7 +95,8 @@ contract TracerPerpetualSwaps is
 	/**
 	 * @notice Allows a user to deposit into their margin account
 	 * @dev this contract must be an approvexd spender of the markets base token on behalf of the depositer.
-	 * @param amount The amount of base tokens to be deposited into the Tracer Market account
+	 * @param amount The amount of base tokens to be deposited into the Tracer Market account. This amount
+	 * should be given with the correct decimal units of the token
 	 */
 	function deposit(uint256 amount) external override {
 		Types.AccountBalance storage userBalance = balances[msg.sender];
@@ -116,7 +117,8 @@ contract TracerPerpetualSwaps is
 	/**
 	 * @notice Allows a user to withdraw from their margin account
 	 * @dev Ensures that the users margin percent is valid after withdraw
-	 * @param amount The amount of margin tokens to be withdrawn from the tracer market account
+	 * @param amount The amount of margin tokens to be withdrawn from the tracer market account. This amount
+	 * should be given in WAD format
 	 */
 	function withdraw(uint256 amount) external override {
 		Types.AccountBalance storage userBalance = balances[msg.sender];

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -107,7 +107,8 @@ contract TracerPerpetualSwaps is
 		_updateAccountLeverage(msg.sender);
 
 		// update market TVL
-		// this cast is safe since amount > 0 on deposit
+		// this cast is safe since amount > 0 on deposit and tokenToWad simply
+		// multiplies the amount up to a WAD value
 		tvl = tvl + uint(amountToUpdate);
 		emit Deposit(msg.sender, amount);
 	}

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -173,8 +173,7 @@ library Balances {
     * @notice converts a wad token amount to its raw representation.
     */
     function wadToToken(uint256 tokenDecimals, uint256 wadAmount) internal pure returns (uint256) {
-        require(wadAmount >= 0, "LBS: wadAmount<0");
-        int scaler = int256(10**(MAX_DECIMALS - tokenDecimals));
+        uint256 scaler = uint256(10**(MAX_DECIMALS - tokenDecimals));
         return uint(wadAmount / scaler);
     }
 }

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -10,6 +10,7 @@ library Balances {
 
     int256 private constant MARGIN_MUL_FACTOR = 10000; // Factor to keep precision in base calcs
     uint256 private constant FEED_UNIT_DIVIDER = 10e7; // used to normalise gas feed prices for base calcs
+    uint256 private constant MAX_DECIMALS = 18;
 
     /**
      * @notice Calculates the new base and position given trade details. Assumes the entire trade will execute
@@ -171,5 +172,23 @@ library Balances {
     ) internal pure returns (int256) {
         quote = quote.abs();
         return quote * price; // 10^18 * 10^8 = 10^26
+    }
+
+    /**
+    * @notice converts a raw token amount to its WAD representation. Used for tokens
+    * that don't have 18 decimal places
+    */
+    function tokenToWad(uint256 tokenDecimals, uint256 amount) internal pure returns (int256) {
+        int scaler = int256(10**(MAX_DECIMALS - tokenDecimals));
+        return amount.toInt256() * scaler;
+    }
+
+    /**
+    * @notice converts a wad token amount to its raw representation.
+    */
+    function wadToToken(uint256 tokenDecimals, uint256 wadAmount) internal pure returns (uint256) {
+        require(wadAmount >= 0, "LBS: wadAmount<0");
+        int scaler = int256(10**(MAX_DECIMALS - tokenDecimals));
+        return uint(wadAmount / scaler);
     }
 }


### PR DESCRIPTION
# Motivation
In order to support WAD maths, rather than each market having some multiply factor, it is much easier to convert each token to a WAD format on deposit (so all internal state is WAD) and then convert it back to a raw token format on withdraw.

# Changes
- introduces base token decimals, since ERC20 tokens are not required to implement the `decimals()` function
- convert token amount to WAD amount on deposit and use this for account state
- convert WAD amount to token amount on withdraw.

# Further Changes
In order for this to be fully supported, some new maths will be needed on the conversion from WAD to raw token amount on withdraw. This is because the correct amount of rounding needs to be done to prevent rounding issues causing withdraw issues. WAD to raw token amount conversions should round down to leave dust in the contract itself.