### PR TITLE
claimEscrow in Liquidation.sol

### DIFF
--- a/contracts/Interfaces/ILiquidation.sol
+++ b/contracts/Interfaces/ILiquidation.sol
@@ -5,8 +5,6 @@ import "../lib/LibPerpetuals.sol";
 import "../lib/LibLiquidation.sol";
 
 interface ILiquidation {
-    function claimEscrow(uint256 id, address trader) external returns (int256);
-
     function calcAmountToReturn(
         uint256 escrowId,
         Perpetuals.Order[] memory orders,

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -13,6 +13,7 @@ interface ITracerPerpetualSwaps {
         int256 liquidateeQuoteChange,
         uint256 amountToEscrow
     ) external;
+
     function updateAccountsOnClaim(
       address claimant,
       int256 amountToGiveToClaimant,

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -15,7 +15,7 @@ interface ITracerPerpetualSwaps {
         uint256 amountToEscrow
     ) external;
 
-	function updateAccountsOnReceiptClaim(
+	function updateAccountsOnClaim(
 		address claimant,
 		int256 amountToGiveToClaimant,
 		address liquidatee,

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -155,8 +155,8 @@ contract Liquidation is ILiquidation, Ownable {
      */
     function claimEscrow(uint256 receiptId) public override {
         LibLiquidation.LiquidationReceipt memory receipt = liquidationReceipts[receiptId];
-        require(receipt.liquidatee == msg.sender, "LIQ: Liquidatee mismatch");
         require(!receipt.escrowClaimed, "LIQ: Escrow claimed");
+        require(receipt.liquidatee == msg.sender, "LIQ: Liquidatee mismatch");
         require(block.timestamp > receipt.releaseTime, "LIQ: Not released");
 
         // Mark as claimed
@@ -164,8 +164,8 @@ contract Liquidation is ILiquidation, Ownable {
 
         // Update balance
         int256 amountToReturn = receipt.escrowedAmount.toInt256();
-        emit ClaimedEscrow(msg.sender, receipt.tracer, receiptId);
-        tracer.updateAccountsOnClaim(address(0), 0, msg.sender, amountToReturn, 0);
+        emit ClaimedEscrow(receipt.liquidatee, receipt.tracer, receiptId);
+        tracer.updateAccountsOnClaim(address(0), 0, receipt.liquidatee, amountToReturn, 0);
     }
 
     /**

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -168,15 +168,14 @@ contract Liquidation is ILiquidation, Ownable {
      * @notice Allows a trader to claim escrowed funds after the escrow period has expired
      * @param receiptId The ID number of the insurance receipt from which funds are being claimed from
      */
-    function claimEscrow(uint256 receiptId, address liquidatee)
+    function claimEscrow(uint256 receiptId)
         public
         override
         onlyTracer
-        returns (int256)
     {
         LibLiquidation.LiquidationReceipt memory receipt =
             liquidationReceipts[receiptId];
-        require(receipt.liquidatee == liquidatee, "LIQ: Liquidatee mismatch");
+        require(receipt.liquidatee == msg.sender, "LIQ: Liquidatee mismatch");
         require(!receipt.escrowClaimed, "LIQ: Escrow claimed");
         require(block.timestamp > receipt.releaseTime, "LIQ: Not released");
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -333,7 +333,7 @@ contract TracerPerpetualSwaps is
 		require(userMarginIsValid(liquidator), "TCR: Taker undermargin");
 	}
 
-	function updateAccountsOnReceiptClaim(
+	function updateAccountsOnClaim(
 		address claimant,
 		int256 amountToGiveToClaimant,
 		address liquidatee,


### PR DESCRIPTION
### Motivation
`claimEscrow` from the old `Accounts.sol` was commented out.

### Changes
**TracerPerpetualSwaps.sol**
- Renamed `updateAccountsOnReceiptClaim` to `updateAccountsOnClaim`, since it is used on escrow claim too

**Liquidation.sol**
- Uncommented `claimEscrow`.
- Merged Account's claimEscrow and Receipt's claimEscrow (from old system) into one function.
- Re-implemented `claimEscrow`