### PR TITLE
Add new account type to `LibBalances`

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -122,7 +122,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
      * @dev Withdraws from tracer, and adds amount to the pool's amount field.
      */
     function updatePoolAmount() public override {
-        int256 base = (tracer.getBalance(address(this))).base;
+        int256 base = (tracer.getBalance(address(this))).position.base;
         if (base > 0) {
             tracer.withdraw(uint256(base));
             poolAmount = poolAmount + uint256(base);

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
-import "./Types.sol";
 import "../lib/LibPerpetuals.sol";
+import "../lib/LibBalances.sol";
 
 interface ITracerPerpetualSwaps {
     function updateAccountsOnLiquidation(
@@ -15,11 +15,11 @@ interface ITracerPerpetualSwaps {
     ) external;
 
     function updateAccountsOnClaim(
-      address claimant,
-      int256 amountToGiveToClaimant,
-      address liquidatee,
-      int256 amountToGiveToLiquidatee,
-      int256 amountToTakeFromInsurance
+        address claimant,
+        int256 amountToGiveToClaimant,
+        address liquidatee,
+        int256 amountToGiveToLiquidatee,
+        int256 amountToTakeFromInsurance
     ) external;
 
     function settle(address account) external;
@@ -49,7 +49,7 @@ interface ITracerPerpetualSwaps {
     function getBalance(address account)
         external
         view
-        returns (Types.AccountBalance memory);
+        returns (Balances.Account memory);
 
     function setInsuranceContract(address insurance) external;
 

--- a/contracts/Interfaces/Types.sol
+++ b/contracts/Interfaces/Types.sol
@@ -4,14 +4,6 @@ pragma solidity ^0.8.0;
 import "../lib/LibPerpetuals.sol";
 
 interface Types {
-    struct AccountBalance {
-        int256 base; // The amount of units in the base asset
-        int256 quote; // The amount of units in the quote asset
-        uint256 totalLeveragedValue;
-        uint256 lastUpdatedIndex;
-        uint256 lastUpdatedGasPrice;
-    }
-
     struct FundingRate {
         uint256 recordTime;
         uint256 recordPrice;

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -160,16 +160,11 @@ contract Liquidation is ILiquidation, Ownable {
         return amountToReturn;
     }
 
-
     /**
      * @notice Allows a trader to claim escrowed funds after the escrow period has expired
      * @param receiptId The ID number of the insurance receipt from which funds are being claimed from
      */
-    function claimEscrow(uint256 receiptId)
-        public
-        override
-        onlyTracer
-    {
+    function claimEscrow(uint256 receiptId) public override onlyTracer {
         LibLiquidation.LiquidationReceipt memory receipt =
             liquidationReceipts[receiptId];
         require(receipt.liquidatee == msg.sender, "LIQ: Liquidatee mismatch");
@@ -182,7 +177,13 @@ contract Liquidation is ILiquidation, Ownable {
         // Update balance
         int256 amountToReturn = receipt.escrowedAmount.toInt256();
         emit ClaimedEscrow(receipt.liquidatee, receipt.tracer, receiptId);
-        tracer.updateAccountsOnClaim(address(0), 0, receipt.liquidatee, amountToReturn, 0);
+        tracer.updateAccountsOnClaim(
+            address(0),
+            0,
+            receipt.liquidatee,
+            amountToReturn,
+            0
+        );
     }
 
     /**
@@ -311,7 +312,7 @@ contract Liquidation is ILiquidation, Ownable {
         )
     {
         /* Liquidator's balance */
-        Types.AccountBalance memory liquidatorBalance =
+        Balances.Account memory liquidatorBalance =
             tracer.getBalance(liquidator);
 
         // Calculates what the updated state of both accounts will be if the liquidation is fully processed
@@ -319,7 +320,7 @@ contract Liquidation is ILiquidation, Ownable {
             LibLiquidation.liquidationBalanceChanges(
                 liquidatedBase,
                 liquidatedQuote,
-                liquidatorBalance.quote,
+                liquidatorBalance.position.quote,
                 amount
             );
     }
@@ -334,14 +335,13 @@ contract Liquidation is ILiquidation, Ownable {
         require(amount > 0, "LIQ: Liquidation amount <= 0");
 
         /* Liquidated account's balance */
-        Types.AccountBalance memory liquidatedBalance =
-            tracer.getBalance(account);
+        Balances.Account memory liquidatedBalance = tracer.getBalance(account);
 
         uint256 amountToEscrow =
             verifyAndSubmitLiquidation(
-                liquidatedBalance.quote,
+                liquidatedBalance.position.quote,
                 pricing.fairPrice(),
-                liquidatedBalance.base,
+                liquidatedBalance.position.base,
                 amount,
                 liquidatedBalance.lastUpdatedGasPrice,
                 account
@@ -360,8 +360,8 @@ contract Liquidation is ILiquidation, Ownable {
             int256 liquidateeQuoteChange
         ) =
             calcLiquidationBalanceChanges(
-                liquidatedBalance.base,
-                liquidatedBalance.quote,
+                liquidatedBalance.position.base,
+                liquidatedBalance.position.quote,
                 msg.sender,
                 amount
             );
@@ -380,7 +380,7 @@ contract Liquidation is ILiquidation, Ownable {
             account,
             msg.sender,
             amount,
-            (liquidatedBalance.quote < 0 ? false : true),
+            (liquidatedBalance.position.quote < 0 ? false : true),
             address(tracer),
             currentLiquidationId - 1
         );
@@ -422,15 +422,18 @@ contract Liquidation is ILiquidation, Ownable {
             uint256 amountWantedFromInsurance =
                 amountToReturn - receipt.escrowedAmount;
 
-            Types.AccountBalance memory insuranceBalance =
+            Balances.Account memory insuranceBalance =
                 tracer.getBalance(insuranceContract);
-            if (insuranceBalance.base >= amountWantedFromInsurance.toInt256()) {
+            if (
+                insuranceBalance.position.base >=
+                amountWantedFromInsurance.toInt256()
+            ) {
                 // We don't need to drain insurance contract
                 // insuranceBalance.base = insuranceBalance.base - amountWantedFromInsurance.toInt256();
                 amountTakenFromInsurance = amountWantedFromInsurance;
             } else {
                 // insuranceBalance.base < amountWantedFromInsurance
-                if (insuranceBalance.base <= 0) {
+                if (insuranceBalance.position.base <= 0) {
                     // attempt to drain entire balance that is needed from the pool
                     IInsurance(insuranceContract).drainPool(
                         amountWantedFromInsurance
@@ -439,18 +442,21 @@ contract Liquidation is ILiquidation, Ownable {
                     // attempt to drain the required balance taking into account the insurance balance in the account contract
                     IInsurance(insuranceContract).drainPool(
                         amountWantedFromInsurance -
-                            uint256(insuranceBalance.base)
+                            uint256(insuranceBalance.position.base)
                     );
                 }
                 if (
-                    insuranceBalance.base < amountWantedFromInsurance.toInt256()
+                    insuranceBalance.position.base <
+                    amountWantedFromInsurance.toInt256()
                 ) {
                     // Still not enough
-                    amountTakenFromInsurance = uint256(insuranceBalance.base);
-                    // insuranceBalance.base = 0;
+                    amountTakenFromInsurance = uint256(
+                        insuranceBalance.position.base
+                    );
+                    // insuranceBalance.position.base = 0;
                 } else {
-                    // insuranceBalance.base >= amountWantedFromInsurance
-                    // insuranceBalance.base = insuranceBalance.base - amountWantedFromInsurance.toInt256();
+                    // insuranceBalance.position.base >= amountWantedFromInsurance
+                    // insuranceBalance.position.base = insuranceBalance.position.base - amountWantedFromInsurance.toInt256();
                     amountTakenFromInsurance = amountWantedFromInsurance;
                 }
             }

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -26,6 +26,13 @@ library Balances {
         Perpetuals.Side side;
     }
 
+    struct Account {
+        Position position;
+        uint256 totalLeveragedValue;
+        uint256 lastUpdatedIndex;
+        uint256 lastUpdatedGasPrice;
+    }
+
     function netValue(Position calldata position, uint256 price)
         public
         pure


### PR DESCRIPTION
# Motivation
Previously, account balance state relied on two separate fields for both base and quote. With the new `Position` type, this is now incorrect. Additionally, the `Types.AccountBalance` type can simply be called `Account` now.

# Changes
 - Define `Account` type in `LibBalances`
 - Remove `Types.AccountBalance`
 - Fix codebase to use new changes
