### PR TITLE
Tracer Leveraged Notional Value to Uint

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -181,10 +181,10 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
      * @dev The target amount is 1% of the leveraged notional value of the tracer being insured.
      */
     function getPoolTarget() public view override returns (uint256) {
-        int256 target = tracer.leveragedNotionalValue() / 100;
+        uint256 target = tracer.leveragedNotionalValue() / 100;
 
         if (target > 0) {
-            return uint256(target);
+            return target;
         } else {
             return 0;
         }
@@ -197,19 +197,21 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
      */
     function getPoolFundingRate() external view override returns (uint256) {
         uint256 multiplyFactor = 3652300;
-        int256 levNotionalValue = tracer.leveragedNotionalValue();
+        uint256 levNotionalValue = tracer.leveragedNotionalValue();
         if (levNotionalValue <= 0) {
             return 0;
         }
 
-        int256 rate =
-            ((multiplyFactor * (getPoolTarget() - poolAmount)).toInt256()) /
-                levNotionalValue;
-        if (rate < 0) {
-            return 0;
-        } else {
-            return uint256(rate);
-        }
+        // todo patch logic with WAD maths
+        // int256 rate =
+        //     ((multiplyFactor * (getPoolTarget() - poolAmount)).toInt256()) /
+        //         levNotionalValue;
+        // if (rate < 0) {
+        //     return 0;
+        // } else {
+        //     return uint256(rate);
+        // }
+        return 0;
     }
 
     /**

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -181,13 +181,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
      * @dev The target amount is 1% of the leveraged notional value of the tracer being insured.
      */
     function getPoolTarget() public view override returns (uint256) {
-        uint256 target = tracer.leveragedNotionalValue() / 100;
-
-        if (target > 0) {
-            return target;
-        } else {
-            return 0;
-        }
+        return tracer.leveragedNotionalValue() / 100;
     }
 
     /**

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -34,7 +34,7 @@ interface ITracerPerpetualSwaps {
 
     function marketId() external view returns (bytes32);
 
-    function leveragedNotionalValue() external view returns (int256);
+    function leveragedNotionalValue() external view returns (uint256);
 
     function gasPriceOracle() external view returns (address);
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -44,7 +44,7 @@ contract TracerPerpetualSwaps is
     // Account State Variables
     mapping(address => Balances.Account) public balances;
     uint256 public tvl;
-    int256 public override leveragedNotionalValue;
+    uint256 public override leveragedNotionalValue;
 
     // Order state
     mapping(bytes32 => uint256) filled;
@@ -272,13 +272,18 @@ contract TracerPerpetualSwaps is
         int256 _newLeverage = accountNewLeveragedNotional.toInt256();
         int256 _oldLeverage = accountOldLeveragedNotional.toInt256();
         int256 accountDelta = _newLeverage - _oldLeverage;
+        int256 _levNotionalValue = 0;
         if (_newLeverage > 0 && _oldLeverage >= 0) {
-            leveragedNotionalValue = leveragedNotionalValue + accountDelta;
+            _levNotionalValue = _levNotionalValue + accountDelta;
         } else if (_newLeverage > 0 && _oldLeverage < 0) {
-            leveragedNotionalValue = leveragedNotionalValue + _newLeverage;
+            _levNotionalValue = _levNotionalValue + _newLeverage;
         } else if (_newLeverage <= 0 && accountDelta < 0 && _oldLeverage > 0) {
-            leveragedNotionalValue = leveragedNotionalValue - _oldLeverage;
+            _levNotionalValue = _levNotionalValue - _oldLeverage;
         }
+
+        leveragedNotionalValue = _levNotionalValue > 0
+            ? uint256(_levNotionalValue)
+            : 0;
     }
 
     function updateAccountsOnLiquidation(


### PR DESCRIPTION
# Motivation
Leveraged notional value of each account had already been migrated to a uint, however the markets leveraged notional value was still an int.

# Changes
- migrate `leveragedNotionalValue` to uint
- update any dependencies

# Note
Commented out code in `getPoolFundingRate()` is being fixed in a parellel PR on the insurance-wad-maths branch