### PR TITLE
Add missing WAD to Tracer perp

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -405,8 +405,10 @@ contract TracerPerpetualSwaps is
                 // calc and pay insurance funding rate
                 // todo CASTING CHECK
                 int256 changeInInsuranceBalance =
-                    (currentInsuranceGlobalRate - currentInsuranceUserRate) *
-                        accountBalance.totalLeveragedValue.toInt256();
+                    PRBMathSD59x18.mul(
+                        currentInsuranceGlobalRate - currentInsuranceUserRate,
+                        accountBalance.totalLeveragedValue.toInt256()
+                    );
 
                 if (changeInInsuranceBalance > 0) {
                     // Only pay insurance fund if required


### PR DESCRIPTION
# Motivation
There was a section were WAD maths was missing in the tracer perp, when computing the insurance funding rate transfers.

# Changes
- add use of WAD maths