### PR TITLE
Fix insurance

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -64,7 +64,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
 
         // convert token amount to WAD
         uint256 amountToUpdate =
-            uint256(Balances.tokenToWad(tracer.baseTokenDecimals(), amount));
+            uint256(Balances.tokenToWad(tracer.quoteTokenDecimals(), amount));
 
         // Update pool balances and user
         updatePoolAmount();
@@ -118,7 +118,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
 
         // convert token amount to raw amount from WAD
         uint256 tokensToSend =
-            Balances.wadToToken(tracer.baseTokenDecimals(), wadTokensToSend);
+            Balances.wadToToken(tracer.quoteTokenDecimals(), wadTokensToSend);
 
         // Pool tokens become margin tokens
         poolToken.burnFrom(msg.sender, amount);


### PR DESCRIPTION
### Motivation
There were changes made to contracts-v2, which broke the branch `swap-base-and-quote`, but they were made after `swap-base-and-quote` last ran its check. I didn't realise this and merged in `swap-base-and-quote` since its most recent check passed.

### Changes
- Changed references to `tracerBaseToken` to quote