### PR TITLE
Added fullLiquidate. Added check to ensure amount < agent's base

### DIFF
--- a/contracts/Interfaces/ILiquidation.sol
+++ b/contracts/Interfaces/ILiquidation.sol
@@ -22,6 +22,8 @@ interface ILiquidation {
         view
         returns (LibLiquidation.LiquidationReceipt memory);
 
+    function fullLiquidate(address account) external;
+
     function liquidate(int256 amount, address account) external;
 
     function claimReceipts(

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -268,17 +268,27 @@ contract Liquidation is ILiquidation, Ownable {
             );
     }
 
+    function fullLiquidate(address account) external override {
+        /* Liquidated account's balance */
+        accountBase = tracer.getBalance(account).position.base;
+        liquidate(accountBase, account);
+    }
+
     /**
      * @notice Liquidates the margin account of a particular user. A deposit is needed from the liquidator.
      *         Generates a liquidation receipt for the liquidator to use should they need a refund.
      * @param amount The amount of tokens to be liquidated
      * @param account The account that is to be liquidated.
      */
-    function liquidate(int256 amount, address account) external override {
+    function liquidate(int256 amount, address account) public override {
         require(amount > 0, "LIQ: Liquidation amount <= 0");
 
         /* Liquidated account's balance */
         Balances.Account memory liquidatedBalance = tracer.getBalance(account);
+        require(
+            amount <= liquidateBalance.position.base,
+            "LIQ: Liquidation amount > account's base"
+        );
 
         uint256 amountToEscrow =
             verifyAndSubmitLiquidation(

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -213,7 +213,7 @@ contract Liquidation is ILiquidation, Ownable {
                 ),
             "LIQ: Account above margin"
         );
-        require(amount <= base.abs(), "LIQ: Liquidate Amount > Position");
+        require(amount <= base.abs(), "LIQ: Liquidate Amount > base");
 
         // calc funds to liquidate and move to Escrow
         uint256 amountToEscrow =
@@ -285,10 +285,6 @@ contract Liquidation is ILiquidation, Ownable {
 
         /* Liquidated account's balance */
         Balances.Account memory liquidatedBalance = tracer.getBalance(account);
-        require(
-            amount <= liquidatedBalance.position.base,
-            "LIQ: Liquidation amount > account's base"
-        );
 
         uint256 amountToEscrow =
             verifyAndSubmitLiquidation(

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -270,7 +270,7 @@ contract Liquidation is ILiquidation, Ownable {
 
     function fullLiquidate(address account) external override {
         /* Liquidated account's balance */
-        accountBase = tracer.getBalance(account).position.base;
+        int256 accountBase = tracer.getBalance(account).position.base;
         liquidate(accountBase, account);
     }
 
@@ -286,7 +286,7 @@ contract Liquidation is ILiquidation, Ownable {
         /* Liquidated account's balance */
         Balances.Account memory liquidatedBalance = tracer.getBalance(account);
         require(
-            amount <= liquidateBalance.position.base,
+            amount <= liquidatedBalance.position.base,
             "LIQ: Liquidation amount > account's base"
         );
 


### PR DESCRIPTION
### Motivation
In the case of full liquidation, the liquidator would have to provide an exact amount to liquidate, in wei. This could be quite difficult, as small amounts of wei could be lost/stuck in the balance. It also means that a liquidator would risk rounding up too much if they were trying to get a complete full liquidation. Overall just bad UX in my opinion.

### Changes
- Added `fullLiquidate`
- Added check to ensure amount < agent's base