### PR TITLE
Test LibInsurance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ private_keys.txt
 yarn-error.log
 artifacts/
 cache/
-
+deployments/

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -90,8 +90,6 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
      * @param amount the amount of pool tokens to burn. Provided in WAD format
      */
     function withdraw(uint256 amount) external override {
-        require(amount > 0, "INS: amount <= 0");
-
         updatePoolAmount();
         uint256 balance = getPoolUserBalance(msg.sender);
         require(balance >= amount, "INS: balance < amount");

--- a/contracts/lib/LibInsurance.sol
+++ b/contracts/lib/LibInsurance.sol
@@ -16,7 +16,10 @@ library LibInsurance {
         if (poolTokenSupply == 0) {
             // Mint at 1:1 ratio if no users in the pool
             return wadAmount;
-        } else {
+        } else if (poolTokenUnderlying == 0) {
+            // avoid divide by 0
+            return 0;
+        }  else {
             // Mint at the correct ratio =
             //          Pool tokens (the ones to be minted) / poolAmount (the collateral asset)
             // Note the difference between this and withdraw. Here we are calculating the amount of tokens
@@ -41,6 +44,11 @@ library LibInsurance {
         uint256 poolTokenUnderlying, // the holding of the insurance pool in quote tokens
         uint256 wadAmount //the WAD amount of tokens being deposited
     ) internal pure returns (uint256) {
+        // avoid division by 0
+        if (poolTokenSupply == 0) {
+            return 0;
+        }
+
         return
             PRBMathUD60x18.mul(
                 PRBMathUD60x18.div(poolTokenUnderlying, poolTokenSupply),

--- a/contracts/lib/LibInsurance.sol
+++ b/contracts/lib/LibInsurance.sol
@@ -19,7 +19,7 @@ library LibInsurance {
         } else if (poolTokenUnderlying == 0) {
             // avoid divide by 0
             return 0;
-        }  else {
+        } else {
             // Mint at the correct ratio =
             //          Pool tokens (the ones to be minted) / poolAmount (the collateral asset)
             // Note the difference between this and withdraw. Here we are calculating the amount of tokens

--- a/contracts/lib/LibInsurance.sol
+++ b/contracts/lib/LibInsurance.sol
@@ -23,6 +23,7 @@ library LibInsurance {
             // to mint, and `amount` is the amount to deposit.
             return
                 PRBMathUD60x18.mul(
+                    // todo what if pool token underlying is 0
                     PRBMathUD60x18.div(poolTokenSupply, poolTokenUnderlying),
                     wadAmount
                 );

--- a/contracts/test/LibInsuranceMock.sol
+++ b/contracts/test/LibInsuranceMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "../lib/LibInsurance.sol";
+
+library LibInsuranceMock {
+    function calcMintAmount(
+        uint256 poolTokenSupply, // the total circulating supply of pool tokens
+        uint256 poolTokenUnderlying, // the holding of the insurance pool in quote tokens
+        uint256 wadAmount //the WAD amount of tokens being deposited
+    ) public pure returns (uint256) {
+        return
+            LibInsurance.calcMintAmount(
+                poolTokenSupply,
+                poolTokenUnderlying,
+                wadAmount
+            );
+    }
+
+    function calcWithdrawAmount(
+        uint256 poolTokenSupply, // the total circulating supply of pool tokens
+        uint256 poolTokenUnderlying, // the holding of the insurance pool in quote tokens
+        uint256 wadAmount //the WAD amount of tokens being deposited
+    ) public pure returns (uint256) {
+        return
+            LibInsurance.calcWithdrawAmount(
+                poolTokenSupply,
+                poolTokenUnderlying,
+                wadAmount
+            );
+    }
+}

--- a/test/unit/LibInsurance.js
+++ b/test/unit/LibInsurance.js
@@ -30,73 +30,93 @@ describe("Unit tests: LibInsurance.sol", function () {
         accounts = await ethers.getSigners()
     })
 
-    context("calcMintAmount", async () => {
-        it("returns 0 if pool token total supply is 0", async () => {
-            let result = await libInsurance.calcMintAmount(zero, zero, zero)
-            expect(result.toString()).to.equal(zero.toString())
+    describe("calcMintAmount", async () => {
+        context("when called with pool token total supply as 0", async () => {
+            it("returns 0", async () => {
+                let result = await libInsurance.calcMintAmount(zero, zero, zero)
+                expect(result.toString()).to.equal(zero.toString())
+            })
         })
 
-        it("returns 0 if the amount to stake is 0", async () => {
-            let result = await libInsurance.calcMintAmount(
-                ethers.utils.parseEther("10"), //pool token supply
-                ethers.utils.parseEther("5"), //collateral held
-                ethers.utils.parseEther("0") //amount of collateral to deposit
-            )
-            expect(result.toString()).to.equal(zero.toString())
+        context("when called with amount to stake as 0", async () => {
+            it("returns 0", async () => {
+                let result = await libInsurance.calcMintAmount(
+                    ethers.utils.parseEther("10"), //pool token supply
+                    ethers.utils.parseEther("5"), //collateral held
+                    ethers.utils.parseEther("0") //amount of collateral to deposit
+                )
+                expect(result.toString()).to.equal(zero.toString())
+            })
         })
 
-        it("returns 0 if the pool token underlying is 0", async () => {
-            let result = await libInsurance.calcMintAmount(
-                ethers.utils.parseEther("10"), //pool token supply
-                ethers.utils.parseEther("0"), //collateral held
-                ethers.utils.parseEther("10") //amount of collateral to deposit
-            )
-            expect(result.toString()).to.equal(zero.toString())
+        context("when called with pool token underlying as 0", async () => {
+            it("returns 0 if the pool token underlying is 0", async () => {
+                let result = await libInsurance.calcMintAmount(
+                    ethers.utils.parseEther("10"), //pool token supply
+                    ethers.utils.parseEther("0"), //collateral held
+                    ethers.utils.parseEther("10") //amount of collateral to deposit
+                )
+                expect(result.toString()).to.equal(zero.toString())
+            })
         })
 
-        it("returns the expected amount", async () => {
-            let expectedResult = ethers.utils.parseEther("20")
-            let result = await libInsurance.calcMintAmount(
-                ethers.utils.parseEther("10"), //pool token supply
-                ethers.utils.parseEther("5"), //collateral held
-                ethers.utils.parseEther("10") //amount of collateral to deposit
-            )
-            expect(result.toString()).to.equal(expectedResult.toString())
+        context("when called with all non zero params", async () => {
+            it("passes", async () => {
+                let expectedResult = ethers.utils.parseEther("20")
+                let result = await libInsurance.calcMintAmount(
+                    ethers.utils.parseEther("10"), //pool token supply
+                    ethers.utils.parseEther("5"), //collateral held
+                    ethers.utils.parseEther("10") //amount of collateral to deposit
+                )
+                expect(result.toString()).to.equal(expectedResult.toString())
+            })
         })
     })
 
-    context("calcWithdrawAmount", async () => {
-        it("returns 0 if pool token total supply is 0", async () => {
-            let result = await libInsurance.calcWithdrawAmount(zero, zero, zero)
-            expect(result.toString()).to.equal(zero.toString())
+    describe("calcWithdrawAmount", async () => {
+        context("when called with pool token total supply as 0", async () => {
+            it("returns 0", async () => {
+                let result = await libInsurance.calcWithdrawAmount(
+                    zero,
+                    zero,
+                    zero
+                )
+                expect(result.toString()).to.equal(zero.toString())
+            })
         })
 
-        it("returns 0 if the amount to withdraw is 0", async () => {
-            let result = await libInsurance.calcWithdrawAmount(
-                ethers.utils.parseEther("10"), //pool token supply
-                ethers.utils.parseEther("5"), //collateral held
-                ethers.utils.parseEther("0") //amount of collateral to deposit
-            )
-            expect(result.toString()).to.equal(zero.toString())
+        context("when called with amount to withdraw as 0", async () => {
+            it("returns 0", async () => {
+                let result = await libInsurance.calcWithdrawAmount(
+                    ethers.utils.parseEther("10"), //pool token supply
+                    ethers.utils.parseEther("5"), //collateral held
+                    ethers.utils.parseEther("0") //amount of collateral to deposit
+                )
+                expect(result.toString()).to.equal(zero.toString())
+            })
         })
 
-        it("returns 0 if the pool token supply is 0", async () => {
-            let result = await libInsurance.calcWithdrawAmount(
-                ethers.utils.parseEther("0"), //pool token supply
-                ethers.utils.parseEther("10"), //collateral held
-                ethers.utils.parseEther("10") //amount of collateral to deposit
-            )
-            expect(result.toString()).to.equal(zero.toString())
+        context("when called with pool token underlying as 0", async () => {
+            it("returns 0", async () => {
+                let result = await libInsurance.calcWithdrawAmount(
+                    ethers.utils.parseEther("5"), //pool token supply
+                    ethers.utils.parseEther("0"), //collateral held
+                    ethers.utils.parseEther("10") //amount of collateral to deposit
+                )
+                expect(result.toString()).to.equal(zero.toString())
+            })
         })
 
-        it("returns the expected amount", async () => {
-            let expectedResult = ethers.utils.parseEther("5")
-            let result = await libInsurance.calcWithdrawAmount(
-                ethers.utils.parseEther("10"), //pool token supply
-                ethers.utils.parseEther("5"), //collateral held
-                ethers.utils.parseEther("10") //amount of pool tokens to withdraw
-            )
-            expect(result.toString()).to.equal(expectedResult.toString())
+        context("when called with all non zero params", async () => {
+            it("passes", async () => {
+                let expectedResult = ethers.utils.parseEther("5")
+                let result = await libInsurance.calcWithdrawAmount(
+                    ethers.utils.parseEther("10"), //pool token supply
+                    ethers.utils.parseEther("5"), //collateral held
+                    ethers.utils.parseEther("10") //amount of pool tokens to withdraw
+                )
+                expect(result.toString()).to.equal(expectedResult.toString())
+            })
         })
     })
 })

--- a/test/unit/LibInsurance.js
+++ b/test/unit/LibInsurance.js
@@ -5,7 +5,7 @@ const { deploy } = deployments
 describe("Unit tests: LibInsurance.sol", function () {
     let libInsurance
     let accounts
-
+    const zero = ethers.utils.parseEther("0")
     before(async function () {
         const { deployer } = await getNamedAccounts()
 
@@ -30,9 +30,97 @@ describe("Unit tests: LibInsurance.sol", function () {
         accounts = await ethers.getSigners()
     })
 
-    context("Its a test", async() => {
-        it("Should pass", async() => {
-            
+    context("calcMintAmount", async() => {
+        it("returns 0 if pool token total supply is 0", async() => {
+            let result = await libInsurance.calcMintAmount(
+                zero,
+                zero,
+                zero
+            )
+            expect(result.toString()).to.equal(
+                zero.toString()
+            )
+        })
+
+        it("returns 0 if the amount to stake is 0", async() => {
+            let result = await libInsurance.calcMintAmount(
+                zero,
+                zero,
+                zero
+            )
+            expect(result.toString()).to.equal(
+                zero.toString()
+            )
+        })
+
+        it("returns 0 if the pool token underlying is 0", async() => {
+            let expectedResult = ethers.utils.parseEther("20")
+            let result = await libInsurance.calcMintAmount(
+                ethers.utils.parseEther("10"), //pool token supply
+                ethers.utils.parseEther("5"), //collateral held
+                ethers.utils.parseEther("10") //amount of collateral to deposit
+            )
+            expect(result.toString()).to.equal(
+                expectedResult.toString()
+            )   
+        })
+
+        it("returns the expected amount", async() => {
+            let result = await libInsurance.calcMintAmount(
+                zero,
+                zero,
+                zero
+            )
+            expect(result.toString()).to.equal(
+                zero.toString()
+            )
+        })
+    })
+
+    context('calcWithdrawAmount', async() => {
+        it("returns 0 if pool token total supply is 0", async() => {
+            let result = await libInsurance.calcMintAmount(
+                zero,
+                zero,
+                zero
+            )
+            expect(result.toString()).to.equal(
+                zero.toString()
+            )
+        })
+
+        it("returns 0 if the amount to stake is 0", async() => {
+            let result = await libInsurance.calcMintAmount(
+                zero,
+                zero,
+                zero
+            )
+            expect(result.toString()).to.equal(
+                zero.toString()
+            )
+        })
+
+        it("returns 0 if the pool token underlying is 0", async() => {
+            let expectedResult = ethers.utils.parseEther("5")
+            let result = await libInsurance.calcWithdrawAmount(
+                ethers.utils.parseEther("10"), //pool token supply
+                ethers.utils.parseEther("5"), //collateral held
+                ethers.utils.parseEther("10") //amount of pool tokens to withdraw
+            )
+            expect(result.toString()).to.equal(
+                expectedResult.toString()
+            )
+        })
+
+        it("returns the expected amount", async() => {
+            let result = await libInsurance.calcMintAmount(
+                zero,
+                zero,
+                zero
+            )
+            expect(result.toString()).to.equal(
+                zero.toString()
+            )
         })
     })
 

--- a/test/unit/LibInsurance.js
+++ b/test/unit/LibInsurance.js
@@ -1,0 +1,40 @@
+const { expect } = require("chai")
+const { ethers, getNamedAccounts, deployments } = require("hardhat")
+const { deploy } = deployments
+
+describe("Unit tests: LibInsurance.sol", function () {
+    let libInsurance
+    let accounts
+
+    before(async function () {
+        const { deployer } = await getNamedAccounts()
+
+        libInsurance = await deploy("LibInsurance", {
+            from: deployer,
+            log: true,
+        })
+
+        await deploy("LibInsuranceMock", {
+            from: deployer,
+            log: true,
+            libraries: {
+                LibLiquidation: libInsurance.address,
+            },
+        })
+
+        let deployment = await deployments.get("LibInsuranceMock")
+        libInsurance = await ethers.getContractAt(
+            deployment.abi,
+            deployment.address
+        )
+        accounts = await ethers.getSigners()
+    })
+
+    context("Its a test", async() => {
+        it("Should pass", async() => {
+            
+        })
+    })
+
+
+})

--- a/test/unit/LibInsurance.js
+++ b/test/unit/LibInsurance.js
@@ -44,9 +44,9 @@ describe("Unit tests: LibInsurance.sol", function () {
 
         it("returns 0 if the amount to stake is 0", async() => {
             let result = await libInsurance.calcMintAmount(
-                zero,
-                zero,
-                zero
+                ethers.utils.parseEther("10"), //pool token supply
+                ethers.utils.parseEther("5"), //collateral held
+                ethers.utils.parseEther("0") //amount of collateral to deposit
             )
             expect(result.toString()).to.equal(
                 zero.toString()
@@ -54,6 +54,17 @@ describe("Unit tests: LibInsurance.sol", function () {
         })
 
         it("returns 0 if the pool token underlying is 0", async() => {
+            let result = await libInsurance.calcMintAmount(
+                ethers.utils.parseEther("10"), //pool token supply
+                ethers.utils.parseEther("0"), //collateral held
+                ethers.utils.parseEther("10") //amount of collateral to deposit
+            )
+            expect(result.toString()).to.equal(
+                zero.toString()
+            )
+        })
+
+        it("returns the expected amount", async() => {
             let expectedResult = ethers.utils.parseEther("20")
             let result = await libInsurance.calcMintAmount(
                 ethers.utils.parseEther("10"), //pool token supply
@@ -64,22 +75,11 @@ describe("Unit tests: LibInsurance.sol", function () {
                 expectedResult.toString()
             )   
         })
-
-        it("returns the expected amount", async() => {
-            let result = await libInsurance.calcMintAmount(
-                zero,
-                zero,
-                zero
-            )
-            expect(result.toString()).to.equal(
-                zero.toString()
-            )
-        })
     })
 
     context('calcWithdrawAmount', async() => {
         it("returns 0 if pool token total supply is 0", async() => {
-            let result = await libInsurance.calcMintAmount(
+            let result = await libInsurance.calcWithdrawAmount(
                 zero,
                 zero,
                 zero
@@ -89,18 +89,29 @@ describe("Unit tests: LibInsurance.sol", function () {
             )
         })
 
-        it("returns 0 if the amount to stake is 0", async() => {
-            let result = await libInsurance.calcMintAmount(
-                zero,
-                zero,
-                zero
+        it("returns 0 if the amount to withdraw is 0", async() => {
+            let result = await libInsurance.calcWithdrawAmount(
+                ethers.utils.parseEther("10"), //pool token supply
+                ethers.utils.parseEther("5"), //collateral held
+                ethers.utils.parseEther("0") //amount of collateral to deposit
             )
             expect(result.toString()).to.equal(
                 zero.toString()
             )
         })
 
-        it("returns 0 if the pool token underlying is 0", async() => {
+        it("returns 0 if the pool token supply is 0", async() => {
+            let result = await libInsurance.calcWithdrawAmount(
+                ethers.utils.parseEther("0"), //pool token supply
+                ethers.utils.parseEther("10"), //collateral held
+                ethers.utils.parseEther("10") //amount of collateral to deposit
+            )
+            expect(result.toString()).to.equal(
+                zero.toString()
+            )
+        })
+
+        it("returns the expected amount", async() => {
             let expectedResult = ethers.utils.parseEther("5")
             let result = await libInsurance.calcWithdrawAmount(
                 ethers.utils.parseEther("10"), //pool token supply
@@ -109,17 +120,6 @@ describe("Unit tests: LibInsurance.sol", function () {
             )
             expect(result.toString()).to.equal(
                 expectedResult.toString()
-            )
-        })
-
-        it("returns the expected amount", async() => {
-            let result = await libInsurance.calcMintAmount(
-                zero,
-                zero,
-                zero
-            )
-            expect(result.toString()).to.equal(
-                zero.toString()
             )
         })
     })

--- a/test/unit/LibInsurance.js
+++ b/test/unit/LibInsurance.js
@@ -30,99 +30,73 @@ describe("Unit tests: LibInsurance.sol", function () {
         accounts = await ethers.getSigners()
     })
 
-    context("calcMintAmount", async() => {
-        it("returns 0 if pool token total supply is 0", async() => {
-            let result = await libInsurance.calcMintAmount(
-                zero,
-                zero,
-                zero
-            )
-            expect(result.toString()).to.equal(
-                zero.toString()
-            )
+    context("calcMintAmount", async () => {
+        it("returns 0 if pool token total supply is 0", async () => {
+            let result = await libInsurance.calcMintAmount(zero, zero, zero)
+            expect(result.toString()).to.equal(zero.toString())
         })
 
-        it("returns 0 if the amount to stake is 0", async() => {
+        it("returns 0 if the amount to stake is 0", async () => {
             let result = await libInsurance.calcMintAmount(
                 ethers.utils.parseEther("10"), //pool token supply
                 ethers.utils.parseEther("5"), //collateral held
                 ethers.utils.parseEther("0") //amount of collateral to deposit
             )
-            expect(result.toString()).to.equal(
-                zero.toString()
-            )
+            expect(result.toString()).to.equal(zero.toString())
         })
 
-        it("returns 0 if the pool token underlying is 0", async() => {
+        it("returns 0 if the pool token underlying is 0", async () => {
             let result = await libInsurance.calcMintAmount(
                 ethers.utils.parseEther("10"), //pool token supply
                 ethers.utils.parseEther("0"), //collateral held
                 ethers.utils.parseEther("10") //amount of collateral to deposit
             )
-            expect(result.toString()).to.equal(
-                zero.toString()
-            )
+            expect(result.toString()).to.equal(zero.toString())
         })
 
-        it("returns the expected amount", async() => {
+        it("returns the expected amount", async () => {
             let expectedResult = ethers.utils.parseEther("20")
             let result = await libInsurance.calcMintAmount(
                 ethers.utils.parseEther("10"), //pool token supply
                 ethers.utils.parseEther("5"), //collateral held
                 ethers.utils.parseEther("10") //amount of collateral to deposit
             )
-            expect(result.toString()).to.equal(
-                expectedResult.toString()
-            )   
+            expect(result.toString()).to.equal(expectedResult.toString())
         })
     })
 
-    context('calcWithdrawAmount', async() => {
-        it("returns 0 if pool token total supply is 0", async() => {
-            let result = await libInsurance.calcWithdrawAmount(
-                zero,
-                zero,
-                zero
-            )
-            expect(result.toString()).to.equal(
-                zero.toString()
-            )
+    context("calcWithdrawAmount", async () => {
+        it("returns 0 if pool token total supply is 0", async () => {
+            let result = await libInsurance.calcWithdrawAmount(zero, zero, zero)
+            expect(result.toString()).to.equal(zero.toString())
         })
 
-        it("returns 0 if the amount to withdraw is 0", async() => {
+        it("returns 0 if the amount to withdraw is 0", async () => {
             let result = await libInsurance.calcWithdrawAmount(
                 ethers.utils.parseEther("10"), //pool token supply
                 ethers.utils.parseEther("5"), //collateral held
                 ethers.utils.parseEther("0") //amount of collateral to deposit
             )
-            expect(result.toString()).to.equal(
-                zero.toString()
-            )
+            expect(result.toString()).to.equal(zero.toString())
         })
 
-        it("returns 0 if the pool token supply is 0", async() => {
+        it("returns 0 if the pool token supply is 0", async () => {
             let result = await libInsurance.calcWithdrawAmount(
                 ethers.utils.parseEther("0"), //pool token supply
                 ethers.utils.parseEther("10"), //collateral held
                 ethers.utils.parseEther("10") //amount of collateral to deposit
             )
-            expect(result.toString()).to.equal(
-                zero.toString()
-            )
+            expect(result.toString()).to.equal(zero.toString())
         })
 
-        it("returns the expected amount", async() => {
+        it("returns the expected amount", async () => {
             let expectedResult = ethers.utils.parseEther("5")
             let result = await libInsurance.calcWithdrawAmount(
                 ethers.utils.parseEther("10"), //pool token supply
                 ethers.utils.parseEther("5"), //collateral held
                 ethers.utils.parseEther("10") //amount of pool tokens to withdraw
             )
-            expect(result.toString()).to.equal(
-                expectedResult.toString()
-            )
+            expect(result.toString()).to.equal(expectedResult.toString())
         })
     })
-
-
 })


### PR DESCRIPTION
# Motivation
Since LibInsurance was quite well defined and easy to test, full unit tests have been produced over just stubbing.

# Changes
- introduce unit tests for LibInsurance
- fix the library to return 0 rather than revert on div by 0
- removes a redundant require that was found in Insurance
- updates gitignore to ignore the deployments folder