### PR TITLE
Remove reverts in Trader.sol

### DIFF
--- a/contracts/Interfaces/ITrader.sol
+++ b/contracts/Interfaces/ITrader.sol
@@ -9,8 +9,7 @@ interface ITrader {
 
     function executeTrade(
         Types.SignedLimitOrder[] memory makers,
-        Types.SignedLimitOrder[] memory takers,
-        address market
+        Types.SignedLimitOrder[] memory takers
     ) external;
 
     function hashOrder(Perpetuals.Order memory order)
@@ -19,11 +18,6 @@ interface ITrader {
         returns (bytes32);
 
     function getDomain() external view returns (bytes32);
-
-    function verify(address signer, Types.SignedLimitOrder memory order)
-        external
-        view
-        returns (bool);
 
     function verifySignature(
         address signer,


### PR DESCRIPTION
# Motivation
Our off chain order matching engine does not want transactions to revert if two transactiosn are unable to be processed as this would create a massive DoS attack vector. As such, invalid transactions should just be skipped over.

# Changes
- updates trader validation code to return bools rather than revert
- use a low level call when calling `matchOrders` on the Tracer perp rather than a direct call (which may revert)