### PR TITLE
Remov a requirement that market is deployed by factory in insurance

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -38,7 +38,6 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     event InsurancePoolDeployed(address indexed market, address indexed asset);
 
     constructor(address _tracer) Ownable() {
-
         tracer = ITracerPerpetualSwaps(_tracer);
         InsurancePoolToken _token =
             new InsurancePoolToken("Tracer Pool Token", "TPT");

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -37,12 +37,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     );
     event InsurancePoolDeployed(address indexed market, address indexed asset);
 
-    constructor(address _tracer, address _perpsFactory) Ownable() {
-        perpsFactory = ITracerPerpetualsFactory(_perpsFactory);
-        require(
-            perpsFactory.validTracers(_tracer),
-            "Pool not deployed by perpsFactory"
-        );
+    constructor(address _tracer) Ownable() {
 
         tracer = ITracerPerpetualSwaps(_tracer);
         InsurancePoolToken _token =

--- a/contracts/Interfaces/deployers/IInsuranceDeployer.sol
+++ b/contracts/Interfaces/deployers/IInsuranceDeployer.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 interface IInsuranceDeployer {
-    function deploy(address tracer, address perpsFactory)
+    function deploy(address tracer)
         external
         returns (address);
 }

--- a/contracts/Interfaces/deployers/IInsuranceDeployer.sol
+++ b/contracts/Interfaces/deployers/IInsuranceDeployer.sol
@@ -2,7 +2,5 @@
 pragma solidity ^0.8.0;
 
 interface IInsuranceDeployer {
-    function deploy(address tracer)
-        external
-        returns (address);
+    function deploy(address tracer) external returns (address);
 }

--- a/contracts/TracerPerpetualsFactory.sol
+++ b/contracts/TracerPerpetualsFactory.sol
@@ -89,7 +89,7 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
 
         // Instantiate Insurance contract for tracer
         address insurance =
-            IInsuranceDeployer(insuranceDeployer).deploy(market, address(this));
+            IInsuranceDeployer(insuranceDeployer).deploy(market);
         address pricing =
             IPricingDeployer(pricingDeployer).deploy(market, insurance, oracle);
         address liquidation =

--- a/contracts/deployers/InsuranceDeployerV1.sol
+++ b/contracts/deployers/InsuranceDeployerV1.sol
@@ -8,11 +8,7 @@ import "../Interfaces/deployers/IInsuranceDeployer.sol";
  * Deployer contract. Used by the Tracer Factory to deploy new Tracer markets
  */
 contract InsuranceDeployerV1 is IInsuranceDeployer {
-    function deploy(address tracer)
-        external
-        override
-        returns (address)
-    {
+    function deploy(address tracer) external override returns (address) {
         Insurance insurance = new Insurance(tracer);
         insurance.transferOwnership(msg.sender);
         return address(insurance);

--- a/contracts/deployers/InsuranceDeployerV1.sol
+++ b/contracts/deployers/InsuranceDeployerV1.sol
@@ -8,12 +8,12 @@ import "../Interfaces/deployers/IInsuranceDeployer.sol";
  * Deployer contract. Used by the Tracer Factory to deploy new Tracer markets
  */
 contract InsuranceDeployerV1 is IInsuranceDeployer {
-    function deploy(address tracer, address perpsFactory)
+    function deploy(address tracer)
         external
         override
         returns (address)
     {
-        Insurance insurance = new Insurance(tracer, perpsFactory);
+        Insurance insurance = new Insurance(tracer);
         insurance.transferOwnership(msg.sender);
         return address(insurance);
     }


### PR DESCRIPTION
### Motivation
Anybody would be able to copy and paste the code to deploy their own markets. The factory can still be used in the same way, to "check" if a market was deployed by the factory. When we moved to a 1:1 insurance:market etc., the factory lost a degree of "importance" because it no longer needs to make sure the "official" insurance/account contracts are using only markets deployed by factory, because there is no "official" insurance & account contract.

Insurance.sol was still making sure that its supplied market was deployed by the factory, despite not being useful.

### Changes
- Removed the check to make sure a tracer market was deployed by the factory in `Insurance.sol`'s constructor.