### PR TITLE
Fix hourly tracer prices indexing

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -20,8 +20,8 @@ contract Pricing is IPricing, Ownable {
     IOracle public oracle;
 
     // pricing metrics
-    Prices.PriceInstant[] internal hourlyTracerPrices;
-    Prices.PriceInstant[] internal hourlyOraclePrices;
+    Prices.PriceInstant[24] internal hourlyTracerPrices;
+    Prices.PriceInstant[24] internal hourlyOraclePrices;
 
     // funding index => funding rate
     mapping(uint256 => Prices.FundingRateInstant) public fundingRates;

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -47,7 +47,7 @@ library Prices {
         return price.cumulativePrice / price.trades;
     }
 
-    function averagePriceForPeriod(PriceInstant[] memory prices)
+    function averagePriceForPeriod(PriceInstant[24] memory prices)
         public
         pure
         returns (uint256)
@@ -79,8 +79,8 @@ library Prices {
 
     function calculateTWAP(
         uint256 hour,
-        PriceInstant[] memory tracerPrices,
-        PriceInstant[] memory oraclePrices
+        PriceInstant[24] memory tracerPrices,
+        PriceInstant[24] memory oraclePrices
     ) public pure returns (TWAP memory) {
         uint256 instantDerivative = 0;
         uint256 cumulativeDerivative = 0;


### PR DESCRIPTION
### Motivation
On line 135 of `Pricing.sol`, it tries to access `currentHour` index of `hourlyTracerPrices`, but `hourlyTracerPrices` has not been initialised so that is an invalid index.

### Changes
- make `hourlyTracerPrices` and `hourlyOraclePrices` statically sized to be a length of 24