### PR TITLE
Removed hourly prices length check. Added divide by zero check

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -311,7 +311,7 @@ contract Pricing is IPricing, Ownable {
         override
         returns (uint256)
     {
-        if (hour >= hourlyTracerPrices.length) {
+        if (hourlyTracerPrices[hour].trades == 0) {
             return 0;
         } else {
             return Prices.averagePrice(hourlyTracerPrices[hour]);
@@ -328,7 +328,7 @@ contract Pricing is IPricing, Ownable {
         override
         returns (uint256)
     {
-        if (hour >= hourlyOraclePrices.length) {
+        if (hourlyOraclePrices[hour].trades == 0) {
             return 0;
         } else {
             return Prices.averagePrice(hourlyOraclePrices[hour]);


### PR DESCRIPTION
### Motivation
Since #100 (making the hourly prices statically sized to 24 elements), `getHourlyAvgTracerPrice` and `getHourlyAvgOraclePrice` don't benefit from checking the length of `hourlyTracerPrices` and `hourlyOraclePrices` respectively.

However, they do need to check for a divide-by-zero, if number of trades in the hour is zero.

I believe this can be done simply like in this PR, but there is probably some Pricing thing that might make this more complicated.

### Changes
- Removed checking the length of `hourlyTracerPrices` and `hourlyOraclePrices` in  `getHourlyAvgTracerPrice` and `getHourlyAvgOraclePrice`
- check for a divide-by-zero, if number of trades in the hour is zero.