### PR TITLE
Deploy package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ yarn.lock
 .env
 build/
 migrations/
-types
+types/
+abi/
 contract-addresses.json
 .vscode/
 *.secret

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@ yarn.lock
 .env
 build/
 migrations/
-types/truffle-contracts/
-types/web3-v1-contracts/
+types
 contract-addresses.json
 .vscode/
 *.secret

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,7 +4,7 @@ require("hardhat-contract-sizer")
 require("hardhat-deploy")
 require("hardhat-prettier")
 require("hardhat-typechain")
-require('hardhat-abi-exporter');
+require("hardhat-abi-exporter")
 
 module.exports = {
     solidity: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,6 +3,7 @@ require("@nomiclabs/hardhat-ethers")
 require("hardhat-contract-sizer")
 require("hardhat-deploy")
 require("hardhat-prettier")
+require("hardhat-typechain")
 
 module.exports = {
     solidity: {
@@ -26,5 +27,8 @@ module.exports = {
         alphaSort: true,
         runOnCompile: true,
         disambiguatePaths: false,
+    },
+    typechain: {
+        outDir: "./types",
     },
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,7 @@ require("hardhat-contract-sizer")
 require("hardhat-deploy")
 require("hardhat-prettier")
 require("hardhat-typechain")
+require('hardhat-abi-exporter');
 
 module.exports = {
     solidity: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@tracer/contracts",
-    "version": "0.1.0",
+    "name": "@tracer-protocol/contracts",
+    "version": "0.2.0",
     "description": "Tracer Protocol",
     "main": "truffle-config.js",
     "directories": {
@@ -28,18 +28,22 @@
     "devDependencies": {
         "@openzeppelin/test-helpers": "^0.5.10",
         "@truffle/contract": "^4.3.3",
+        "@typechain/ethers-v5": "^2.0.0",
         "arb-ethers-web3-bridge": "^0.7.3",
         "chai": "^4.3.4",
         "ganache-cli": "^6.12.0",
         "hardhat": "^2.2.1",
         "hardhat-contract-sizer": "^2.0.3",
         "hardhat-deploy": "^0.7.5",
+        "hardhat-typechain": "^0.3.5",
         "mocha": "^8.2.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
         "solidity-docgen": "^0.5.11",
         "truffle": "^5.1.33",
         "truffle-assertions": "^0.9.2",
+        "ts-generator": "^0.1.1",
+        "typechain": "^4.0.3",
         "web3": "^1.3.0",
         "web3-core": "^1.3.0",
         "web3-eth-contract": "^1.3.0"
@@ -52,7 +56,8 @@
         "ganache": "ganache-cli -l 8500000",
         "lint": "prettier --check . && yarn hardhat check",
         "lint:fix": "prettier . --write",
-        "clean": "npm-run-all -p clean:artifacts clean:cache",
+        "clean": "npm-run-all -p clean:artifacts clean:cache clean:types",
+	"clean:types": "rimraf ./types/",
         "clean:artifacts": "rimraf ./artifacts/",
         "clean:cache": "rimraf ./cache/",
         "solhint": "./node_modules/.bin/solhint -f table contracts/**/*.sol"
@@ -64,7 +69,7 @@
     "license": "ISC",
     "bugs": {},
     "files": [
-        "contracts",
+        "types",
         "build"
     ],
     "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tracer-protocol/contracts",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Tracer Protocol",
     "main": "truffle-config.js",
     "directories": {
@@ -33,6 +33,7 @@
         "chai": "^4.3.4",
         "ganache-cli": "^6.12.0",
         "hardhat": "^2.2.1",
+        "hardhat-abi-exporter": "^2.2.1",
         "hardhat-contract-sizer": "^2.0.3",
         "hardhat-deploy": "^0.7.5",
         "hardhat-typechain": "^0.3.5",
@@ -69,8 +70,8 @@
     "license": "ISC",
     "bugs": {},
     "files": [
-        "artifacts",
-        "build"
+        "types",
+        "abi"
     ],
     "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tracer-protocol/contracts",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "Tracer Protocol",
     "main": "truffle-config.js",
     "directories": {
@@ -69,7 +69,7 @@
     "license": "ISC",
     "bugs": {},
     "files": [
-        "types",
+        "artifacts",
         "build"
     ],
     "engines": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "lint": "prettier --check . && yarn hardhat check",
         "lint:fix": "prettier . --write",
         "clean": "npm-run-all -p clean:artifacts clean:cache clean:types",
-	"clean:types": "rimraf ./types/",
+        "clean:types": "rimraf ./types/",
         "clean:artifacts": "rimraf ./artifacts/",
         "clean:cache": "rimraf ./cache/",
         "solhint": "./node_modules/.bin/solhint -f table contracts/**/*.sol"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tracer-protocol/contracts",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Tracer Protocol",
     "main": "truffle-config.js",
     "directories": {


### PR DESCRIPTION
### Motivation
- Frontend no longer had ffffresh types for typescript
- had old stinky types

### Changes
- add typechain types
- bump package version
- change package name back to @tracer-protocol/contracts