### PR TITLE
Made feeRate 0% in deployment

### DIFF
--- a/deploy/FullDeploy.js
+++ b/deploy/FullDeploy.js
@@ -165,7 +165,7 @@ module.exports = async function (hre) {
 
     let maxLeverage = new ethers.BigNumber.from("125000").toString()
     let tokenDecimals = new ethers.BigNumber.from("8").toString()
-    let feeRate = "5000000000000000000" // 5 percent
+    let feeRate = 0 // 0 percent
     let fundingRateSensitivity = 1
 
     const tracer = await deploy("TracerPerpetualSwaps", {

--- a/scripts/DeployAndAddTracer.js
+++ b/scripts/DeployAndAddTracer.js
@@ -9,7 +9,7 @@ async function main() {
     await deployments.fixture(["FullDeploy"])
     let maxLeverage = new ethers.BigNumber.from("125000").toString()
     let tokenDecimals = new ethers.BigNumber.from("1000000").toString()
-    let feeRate = "5000000000000000000" // 5 percent
+    let feeRate = 0 // 0 percent
     let maxLiquidationSlippage = "50000000000000000000" // 50 percent
     let fundingRateSensitivity = 1
     let gasPriceOracle = await deployments.get("Oracle")


### PR DESCRIPTION
### Motivation
We should make feeRate 0% for testing, unless we are specifically testing the feeRate itself

### Changes
- Make `feeRate` 0% in both `deploy/FullDeploy.js` and `scripts/DeployAndAddTracer`.