### PR TITLE
Wadify Funding Sensitivity

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -7,13 +7,13 @@ import "./Interfaces/IPricing.sol";
 import "./Interfaces/ITracerPerpetualSwaps.sol";
 import "./Interfaces/IInsurance.sol";
 import "./Interfaces/IOracle.sol";
-import "prb-math/contracts/PRBMathUD60x18.sol";
+import "prb-math/contracts/PRBMathSD59x18.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract Pricing is IPricing, Ownable {
     using LibMath for uint256;
     using LibMath for int256;
-    using PRBMathUD60x18 for uint256;
+    using PRBMathSD59x18 for int256;
 
     address public tracer;
     IInsurance public insurance;
@@ -97,10 +97,7 @@ contract Pricing is IPricing, Ownable {
             // Update pricing and funding rate states
             updatePrice(tradePrice, currentOraclePrice, true);
 
-            // todo contract needs to take in the insurance pool
-            int256 poolFundingRate = insurance.getPoolFundingRate().toInt256();
-
-            updateFundingRate(currentOraclePrice, poolFundingRate);
+            updateFundingRate(currentOraclePrice);
 
             if (startLast24Hours <= block.timestamp - 24 hours) {
                 // Update the interest rate every 24 hours
@@ -158,20 +155,23 @@ contract Pricing is IPricing, Ownable {
     /**
      * @notice Updates the funding rate and the insurance funding rate
      * @param oraclePrice The price of the underlying asset that the Tracer is based upon as returned by a Chainlink Oracle
-     * @param iPoolFundingRate The 8 hour funding rate for the insurance pool, returned by a tracer's insurance contract
      */
-    function updateFundingRate(uint256 oraclePrice, int256 iPoolFundingRate)
-        internal
-    {
+    function updateFundingRate(uint256 oraclePrice) internal {
         // Get 8 hour time-weighted-average price (TWAP) and calculate the new funding rate and store it a new variable
         ITracerPerpetualSwaps _tracer = ITracerPerpetualSwaps(tracer);
         Prices.TWAP memory twapPrices = getTWAPs(currentHour);
+        int256 iPoolFundingRate = insurance.getPoolFundingRate().toInt256();
         uint256 underlyingTWAP = twapPrices.underlying;
         uint256 derivativeTWAP = twapPrices.derivative;
+
         int256 newFundingRate =
-            (derivativeTWAP.toInt256() -
-                underlyingTWAP.toInt256() -
-                timeValue) * (_tracer.fundingRateSensitivity().toInt256());
+            PRBMathSD59x18.mul(
+                derivativeTWAP.toInt256() -
+                    underlyingTWAP.toInt256() -
+                    timeValue,
+                _tracer.fundingRateSensitivity().toInt256()
+            );
+
         // set the index to the last funding Rate confirmed funding rate (-1)
         uint256 fundingIndex = currentFundingIndex - 1;
 
@@ -179,7 +179,8 @@ contract Pricing is IPricing, Ownable {
         int256 currentFundingRateValue =
             fundingRates[fundingIndex].cumulativeFundingRate;
         int256 cumulativeFundingRate =
-            currentFundingRateValue + (newFundingRate * oraclePrice.toInt256());
+            currentFundingRateValue +
+                PRBMathSD59x18.mul(newFundingRate, oraclePrice.toInt256());
 
         // as above but with insurance funding rate value
         int256 currentInsuranceFundingRateValue =

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -26,7 +26,7 @@ contract TracerPerpetualSwaps is
     using PRBMathSD59x18 for int256;
     using PRBMathUD60x18 for uint256;
 
-    uint256 public override fundingRateSensitivity;
+    uint256 public override fundingRateSensitivity; //WAD value. sensitivity of 1 = 1*10^18
     uint256 public constant override LIQUIDATION_GAS_COST = 63516;
     // todo ensure these are fine being immutable
     address public immutable override tracerQuoteToken;

--- a/contracts/lib/LibInsurance.sol
+++ b/contracts/lib/LibInsurance.sol
@@ -26,7 +26,6 @@ library LibInsurance {
             // to mint, and `amount` is the amount to deposit.
             return
                 PRBMathUD60x18.mul(
-                    // todo what if pool token underlying is 0
                     PRBMathUD60x18.div(poolTokenSupply, poolTokenUnderlying),
                     wadAmount
                 );
@@ -42,7 +41,7 @@ library LibInsurance {
     function calcWithdrawAmount(
         uint256 poolTokenSupply, // the total circulating supply of pool tokens
         uint256 poolTokenUnderlying, // the holding of the insurance pool in quote tokens
-        uint256 wadAmount //the WAD amount of tokens being deposited
+        uint256 wadAmount //the WAD amount of tokens being withdrawn
     ) internal pure returns (uint256) {
         // avoid division by 0
         if (poolTokenSupply == 0) {


### PR DESCRIPTION
# Motivation
To keep consistency, it makes sense for Funding Sensitivity to be a WAD value. This way we can have very low funding sensitivity if needed and it allows us to keep precision in calcs.

# Changes
- make assumption funding sensitivity is wad and update calcs in pricing
- update comments
- remove PRB unsigned math from Pricing as its not used
- get rid of redundant function argument in pricing 