### PR TITLE
fix calculateTWAP and patch tcr-07

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -87,13 +87,6 @@ contract Pricing is IPricing, Ownable {
             uint256 hourlyTracerPrice = getHourlyAvgTracerPrice(currentHour);
             emit HourlyPriceUpdated(hourlyTracerPrice, currentHour);
 
-            // Update the price to a new entry and funding rate every hour
-            // Check current hour and loop around if need be
-            if (currentHour == 23) {
-                currentHour = 0;
-            } else {
-                currentHour = currentHour + 1;
-            }
             // Update pricing and funding rate states
             updatePrice(tradePrice, currentOraclePrice, true);
 
@@ -108,7 +101,14 @@ contract Pricing is IPricing, Ownable {
                 startLast24Hours = block.timestamp;
             }
 
+            // update time metrics after all other state
             startLastHour = block.timestamp;
+            // Check current hour and loop around if need be
+            if (currentHour == 23) {
+                currentHour = 0;
+            } else {
+                currentHour = currentHour + 1;
+            }
         } else {
             // Update old pricing entry
             updatePrice(tradePrice, currentOraclePrice, false);

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -101,7 +101,9 @@ library Prices {
 
         for (uint256 i = 0; i < 8; i++) {
             uint256 currTimeWeight = 8 - i;
-            uint256 j = hour < i ? 23 : hour - i;
+            // if hour < i loop back towards 0 from 23.
+            // otherwise move from hour towards 0
+            uint256 j = hour < i ? 23 - i + hour : hour - i;
 
             uint256 currDerivativePrice = averagePrice(tracerPrices[j]);
             uint256 currUnderlyingPrice = averagePrice(oraclePrices[j]);

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -23,12 +23,12 @@ library Prices {
         uint256 derivative;
     }
 
-    function fairPrice(uint256 oraclePrice, int256 timeValue)
+    function fairPrice(uint256 oraclePrice, int256 _timeValue)
         public
         pure
         returns (uint256)
     {
-        return uint256(LibMath.abs(oraclePrice.toInt256() - timeValue));
+        return uint256(LibMath.abs(oraclePrice.toInt256() - _timeValue));
     }
 
     function timeValue(uint256 averageTracerPrice, uint256 averageOraclePrice)
@@ -67,19 +67,28 @@ library Prices {
     }
 
     function globalLeverage(
-        uint256 globalLeverage,
+        uint256 _globalLeverage,
         uint256 oldLeverage,
         uint256 newLeverage
     ) public pure returns (uint256) {
         bool leverageHasIncreased = newLeverage > oldLeverage;
 
         if (leverageHasIncreased) {
-            return globalLeverage + (newLeverage - oldLeverage);
+            return _globalLeverage + (newLeverage - oldLeverage);
         } else {
-            return globalLeverage - (newLeverage - oldLeverage);
+            return _globalLeverage - (newLeverage - oldLeverage);
         }
     }
 
+    /**
+     * @notice calculates an 8 hour TWAP starting at the hour index amd moving
+     * backwards in time.
+     * @param hour the 24 hour index to start at
+     * @param tracerPrices the average hourly prices of the derivative over the last
+     * 24 hours
+     * @param oraclePrices the average hourly prices of the oracle over the last
+     * 24 hours
+     */
     function calculateTWAP(
         uint256 hour,
         PriceInstant[24] memory tracerPrices,
@@ -92,7 +101,7 @@ library Prices {
 
         for (uint256 i = 0; i < 8; i++) {
             uint256 currTimeWeight = 8 - i;
-            uint256 j = 8 - i;
+            uint256 j = hour < i ? 23 : hour - i;
 
             uint256 currDerivativePrice = averagePrice(tracerPrices[j]);
             uint256 currUnderlyingPrice = averagePrice(oraclePrices[j]);


### PR DESCRIPTION
# Motivation
The current approach for calculating TWAPs was incorrectly implemented as it wasn't factoring in the `hour` parameter. Also took the opportunity to patch the bug with calculating the TWAP with only a single entry when updating internal parameters in the pricing contract.

# Changes
- twap accounts for `hour` param
- compute twap before incrementing hour in `pricing.sol`