### PR TITLE
Use `LibBalances` throughout contracts

### DIFF
--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -78,7 +78,6 @@ interface ITracerPerpetualSwaps {
 
     function matchOrders(
         Perpetuals.Order memory order1,
-        Perpetuals.Order memory order2,
-        uint256 fillAmount
+        Perpetuals.Order memory order2
     ) external;
 }

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -213,27 +213,27 @@ contract TracerPerpetualSwaps is
         bytes32 orderId1 = Perpetuals.orderId(order1);
         bytes32 orderId2 = Perpetuals.orderId(order2);
 
+        uint256 fillAmount =
+            Balances.fillAmount(
+                trade1,
+                filled[orderId1],
+                trade2,
+                filled[orderId2]
+            );
+
         // Calculate new account state
         (Balances.Position memory newPos1, Balances.Position memory newPos2) =
             (
                 Balances.applyTrade(
                     account1.position,
                     trade1,
-                    Balances.fillAmount(
-                        trade1,
-                        filled[orderId1],
-                        filled[orderId2]
-                    ),
+                    fillAmount,
                     feeRate
                 ),
                 Balances.applyTrade(
                     account2.position,
                     trade2,
-                    Balances.fillAmount(
-                        trade2,
-                        filled[orderId1],
-                        filled[orderId2]
-                    ),
+                    fillAmount,
                     feeRate
                 )
             );
@@ -243,7 +243,6 @@ contract TracerPerpetualSwaps is
         account2.position = newPos2;
 
         // Add fee into cumulative fees
-        uint256 fillAmount = LibMath.min(order1.amount, order2.amount);
         int256 quoteChange =
             PRBMathUD60x18.mul(fillAmount, order1.price).toInt256();
         int256 fee =

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -155,12 +155,10 @@ contract TracerPerpetualSwaps is
      * @notice Match two orders that exist on chain against each other
      * @param order1 the first order
      * @param order2 the second order
-     * @param fillAmount the amount to be filled as sent by the trader
      */
     function matchOrders(
         Perpetuals.Order memory order1,
-        Perpetuals.Order memory order2,
-        uint256 fillAmount
+        Perpetuals.Order memory order2
     ) public override onlyWhitelisted {
         uint256 filled1 = filled[Perpetuals.orderId(order1)];
         uint256 filled2 = filled[Perpetuals.orderId(order2)];
@@ -184,7 +182,7 @@ contract TracerPerpetualSwaps is
 
         // Update internal trade state
         // note: price has already been validated here, so order 1 price can be used
-        pricingContract.recordTrade(order1.price, fillAmount);
+        pricingContract.recordTrade(order1.price, LibMath.min(order1.amount, order2.amount));
 
         // Ensures that you are in a position to take the trade
         require(

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -471,7 +471,8 @@ contract TracerPerpetualSwaps is
         uint256 price = pricingContract.fairPrice();
         uint256 gasCost = gasPrice * LIQUIDATION_GAS_COST;
 
-        Balances.Position memory pos = Balances.Position(quote, base);
+        Balances.Position memory pos =
+            Balances.Position(position.quote, position.base);
         uint256 minMargin =
             Balances.minimumMargin(pos, price, gasCost, maxLeverage);
         int256 margin = Balances.margin(pos, price);
@@ -485,7 +486,7 @@ contract TracerPerpetualSwaps is
         if (minMargin == 0) {
             // minMargin = 0 only occurs when user has no base (positions)
             // if they have no base, their quote must be > 0.
-            return quote >= 0;
+            return position.quote >= 0;
         }
 
         return Balances.marginValid(position, price, gasCost, maxLeverage);

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -216,8 +216,26 @@ contract TracerPerpetualSwaps is
         // Calculate new account state
         (Balances.Position memory newPos1, Balances.Position memory newPos2) =
             (
-                Balances.applyTrade(account1.position, trade1, Balances.fillAmount(trade1, filled[orderId1], filled[orderId2]), feeRate),
-                Balances.applyTrade(account2.position, trade2, Balances.fillAmount(trade2, filled[orderId1], filled[orderId2]), feeRate)
+                Balances.applyTrade(
+                    account1.position,
+                    trade1,
+                    Balances.fillAmount(
+                        trade1,
+                        filled[orderId1],
+                        filled[orderId2]
+                    ),
+                    feeRate
+                ),
+                Balances.applyTrade(
+                    account2.position,
+                    trade2,
+                    Balances.fillAmount(
+                        trade2,
+                        filled[orderId1],
+                        filled[orderId2]
+                    ),
+                    feeRate
+                )
             );
 
         // Update account state with results of above calculation

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -367,14 +367,8 @@ contract TracerPerpetualSwaps is
             Balances.Account storage insuranceBalance =
                 balances[address(insuranceContract)];
 
-            // Calc the difference in funding rates, remove price multiply factor
-            int256 fundingDiff =
-                currGlobalRate.fundingRate - currUserRate.fundingRate;
+            accountBalance.position = Prices.applyFunding(accountBalance.position, currGlobalRate, currUserRate);
 
-            // quote - (fundingDiff * base)
-            accountBalance.position.quote =
-                accountBalance.position.quote -
-                PRBMathSD59x18.mul(fundingDiff, accountBalance.position.base);
             // Update account gas price
             accountBalance.lastUpdatedGasPrice = IOracle(gasPriceOracle)
                 .latestAnswer();
@@ -404,7 +398,7 @@ contract TracerPerpetualSwaps is
             // Update account index
             accountBalance.lastUpdatedIndex = pricingContract
                 .currentFundingIndex();
-            require(userMarginIsValid(account), "TCR: Target under-margined ");
+            require(userMarginIsValid(account), "TCR: Target under-margined");
             emit Settled(account, accountBalance.position.quote);
         }
     }

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -374,25 +374,10 @@ contract TracerPerpetualSwaps is
                 .latestAnswer();
 
             if (accountBalance.totalLeveragedValue > 0) {
-                // calc and pay insurance funding rate
-                // todo CASTING CHECK
-                int256 changeInInsuranceBalance =
-                    PRBMathSD59x18.mul(
-                        currInsuranceGlobalRate.fundingRate -
-                            currInsuranceUserRate.fundingRate,
-                        accountBalance.totalLeveragedValue.toInt256()
-                    );
+                (Balances.Position memory newUserPos, Balances.Position memory newInsurancePos) = Prices.applyInsurance(accountBalance.position, insuranceBalance.position, currGlobalRate, currUserRate, accountBalance.totalLeveragedValue);
 
-                if (changeInInsuranceBalance > 0) {
-                    // Only pay insurance fund if required
-                    accountBalance.position.quote =
-                        accountBalance.position.quote -
-                        changeInInsuranceBalance;
-                    insuranceBalance.position.quote =
-                        insuranceBalance.position.quote +
-                        changeInInsuranceBalance;
-                    // uint is safe since changeInInsuranceBalance > 0
-                }
+                balances[account].position = newUserPos;
+                balances[(address(insuranceContract))].position = newInsurancePos;
             }
 
             // Update account index

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -210,11 +210,14 @@ contract TracerPerpetualSwaps is
                 Balances.Trade(order2.price, order2.amount, order2.side)
             );
 
+        bytes32 orderId1 = Perpetuals.orderId(order1);
+        bytes32 orderId2 = Perpetuals.orderId(order2);
+
         // Calculate new account state
         (Balances.Position memory newPos1, Balances.Position memory newPos2) =
             (
-                Balances.applyTrade(account1.position, trade1, feeRate),
-                Balances.applyTrade(account2.position, trade2, feeRate)
+                Balances.applyTrade(account1.position, trade1, Balances.fillAmount(trade1, filled[orderId1], filled[orderId2]), feeRate),
+                Balances.applyTrade(account2.position, trade2, Balances.fillAmount(trade2, filled[orderId1], filled[orderId2]), feeRate)
             );
 
         // Update account state with results of above calculation

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -111,11 +111,12 @@ library Balances {
     }
 
     function fillAmount(
-        Trade memory trade,
-        uint256 a,
-        uint256 b
+        Trade memory tradeA,
+        uint256 fillA,
+        Trade memory tradeB,
+        uint256 fillB
     ) internal pure returns (uint256) {
-        return LibMath.min(trade.amount - a, trade.amount - b);
+        return LibMath.min(tradeA.amount - fillA, tradeB.amount - fillB);
     }
 
     function applyTrade(

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -144,7 +144,9 @@ library Balances {
         uint256 liquidationCost,
         uint256 maximumLeverage
     ) internal pure returns (bool) {
-        return uint256(margin(position, price)) >= minimumMargin(position, price, liquidationCost, maximumLeverage);
+        return
+            uint256(margin(position, price)) >=
+            minimumMargin(position, price, liquidationCost, maximumLeverage);
     }
 
     /**

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -110,11 +110,22 @@ library Balances {
         return liquidationGasCost + minimumMarginWithoutGasCost;
     }
 
+    function fillAmount(
+        Trade memory trade,
+        uint256 a,
+        uint256 b
+    ) internal pure returns (uint256) {
+        return LibMath.min(trade.amount - a, trade.amount - b);
+    }
+
     function applyTrade(
         Position memory position,
         Trade memory trade,
+        uint256 fill,
         uint256 feeRate
-    ) public pure returns (Position memory) {
+    ) internal pure returns (Position memory) {
+        require(fill <= trade.amount);
+
         int256 signedAmount = LibMath.toInt256(trade.amount);
         int256 signedPrice = LibMath.toInt256(trade.price);
         int256 signedFeeRate = LibMath.toInt256(feeRate);

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -33,7 +33,7 @@ library Balances {
         uint256 lastUpdatedGasPrice;
     }
 
-    function netValue(Position calldata position, uint256 price)
+    function netValue(Position memory position, uint256 price)
         public
         pure
         returns (uint256)
@@ -47,7 +47,7 @@ library Balances {
      * @param position the position the account is currently in
      * @param price The price of the base asset
      */
-    function margin(Position calldata position, uint256 price)
+    function margin(Position memory position, uint256 price)
         public
         pure
         returns (int256)
@@ -73,7 +73,7 @@ library Balances {
      * @param position The position the account is currently in
      * @param price The price of the base asset
      */
-    function leveragedNotionalValue(Position calldata position, uint256 price)
+    function leveragedNotionalValue(Position memory position, uint256 price)
         public
         pure
         returns (uint256)
@@ -91,7 +91,7 @@ library Balances {
     }
 
     function minimumMargin(
-        Position calldata position,
+        Position memory position,
         uint256 price,
         uint256 liquidationCost,
         uint256 maximumLeverage
@@ -111,8 +111,8 @@ library Balances {
     }
 
     function applyTrade(
-        Position calldata position,
-        Trade calldata trade,
+        Position memory position,
+        Trade memory trade,
         uint256 feeRate
     ) public pure returns (Position memory) {
         int256 signedAmount = LibMath.toInt256(trade.amount);
@@ -136,6 +136,15 @@ library Balances {
         Position memory newPosition = Position(newQuote, newBase);
 
         return newPosition;
+    }
+
+    function marginValid(
+        Position memory position,
+        uint256 price,
+        uint256 liquidationCost,
+        uint256 maximumLeverage
+    ) internal pure returns (bool) {
+        return uint256(margin(position, price)) >= minimumMargin(position, price, liquidationCost, maximumLeverage);
     }
 
     /**

--- a/contracts/lib/LibMath.sol
+++ b/contracts/lib/LibMath.sol
@@ -29,4 +29,12 @@ library LibMath {
 
         return sum(arr) / n;
     }
+
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    function signedMin(int256 a, int256 b) internal pure returns (int256) {
+        return a < b ? a : b;
+    }
 }

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -148,4 +148,31 @@ library Prices {
             position.base
         );
     }
+
+    function applyInsurance(
+        Balances.Position memory userPosition,
+        Balances.Position memory insurancePosition,
+        FundingRateInstant memory globalRate,
+        FundingRateInstant memory userRate,
+        uint256 totalLeveragedValue
+    ) internal pure returns (Balances.Position memory, Balances.Position memory) {
+        int256 insuranceDelta = PRBMathSD59x18.mul(globalRate.fundingRate - userRate.fundingRate, int256(totalLeveragedValue));
+
+        if (insuranceDelta > 0) {
+        Balances.Position memory newUserPos = Balances.Position(
+            userPosition.quote - insuranceDelta,
+            userPosition.base
+        );
+
+        Balances.Position memory newInsurancePos = Balances.Position(
+            insurancePosition.quote + insuranceDelta,
+            insurancePosition.base
+        );
+        
+
+        return (newUserPos, newInsurancePos);
+        } else {
+            return (userPosition, insurancePosition);
+        }
+    }
 }

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.0;
 
 import "./LibMath.sol";
+import "./LibBalances.sol";
 import "prb-math/contracts/PRBMathUD60x18.sol";
+import "prb-math/contracts/PRBMathSD59x18.sol";
 
 library Prices {
     using LibMath for uint256;
@@ -134,5 +136,16 @@ library Prices {
                     );
             }
         }
+    }
+
+    function applyFunding(
+        Balances.Position memory position,
+        FundingRateInstant memory globalRate,
+        FundingRateInstant memory userRate
+    ) internal pure returns (Balances.Position memory) {
+        return Balances.Position(
+            position.quote - PRBMathSD59x18.mul(globalRate.fundingRate - userRate.fundingRate, position.base),
+            position.base
+        );
     }
 }

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -143,10 +143,15 @@ library Prices {
         FundingRateInstant memory globalRate,
         FundingRateInstant memory userRate
     ) internal pure returns (Balances.Position memory) {
-        return Balances.Position(
-            position.quote - PRBMathSD59x18.mul(globalRate.fundingRate - userRate.fundingRate, position.base),
-            position.base
-        );
+        return
+            Balances.Position(
+                position.quote -
+                    PRBMathSD59x18.mul(
+                        globalRate.fundingRate - userRate.fundingRate,
+                        position.base
+                    ),
+                position.base
+            );
     }
 
     function applyInsurance(
@@ -155,22 +160,31 @@ library Prices {
         FundingRateInstant memory globalRate,
         FundingRateInstant memory userRate,
         uint256 totalLeveragedValue
-    ) internal pure returns (Balances.Position memory, Balances.Position memory) {
-        int256 insuranceDelta = PRBMathSD59x18.mul(globalRate.fundingRate - userRate.fundingRate, int256(totalLeveragedValue));
+    )
+        internal
+        pure
+        returns (Balances.Position memory, Balances.Position memory)
+    {
+        int256 insuranceDelta =
+            PRBMathSD59x18.mul(
+                globalRate.fundingRate - userRate.fundingRate,
+                int256(totalLeveragedValue)
+            );
 
         if (insuranceDelta > 0) {
-        Balances.Position memory newUserPos = Balances.Position(
-            userPosition.quote - insuranceDelta,
-            userPosition.base
-        );
+            Balances.Position memory newUserPos =
+                Balances.Position(
+                    userPosition.quote - insuranceDelta,
+                    userPosition.base
+                );
 
-        Balances.Position memory newInsurancePos = Balances.Position(
-            insurancePosition.quote + insuranceDelta,
-            insurancePosition.base
-        );
-        
+            Balances.Position memory newInsurancePos =
+                Balances.Position(
+                    insurancePosition.quote + insuranceDelta,
+                    insurancePosition.base
+                );
 
-        return (newUserPos, newInsurancePos);
+            return (newUserPos, newInsurancePos);
         } else {
             return (userPosition, insurancePosition);
         }


### PR DESCRIPTION
# Motivation
The recent refactor focused primarily on extracting logic into separate libraries. While this has progressed well, some of the actual contracts themselves likely contain artifacts of the previous, non-library implementation. These need to be changed.

# Changes
 - Refactor `executeTrade` to use the corresponding `LibBalances.applyTrade` (which was written for this exact purpose)
 - Remove the (largely redundant) `fillAmount` parameter from the external interface
 - Extract margin validation into `LibBalances`
 - Extract funding rate calculations into `LibPrices`
 - Extract insurance calculations into `LibPrices`
