### PR TITLE
Switch liquidation receipts to use enum Side

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -150,7 +150,6 @@ contract Liquidation is ILiquidation, Ownable {
             if (
                 order.created < receipt.time || // Order made before receipt
                 order.maker != receipt.liquidator || // Order made by someone who isn't liquidator
-                // todo alter liquidations side to be a Side type, then re add this comparison
                 order.side == receipt.liquidationSide // Order is in same direction as liquidation
                 /* Order should be the opposite to the position acquired on liquidation */
             ) {

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -4,6 +4,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./lib/LibMath.sol";
 import "./lib/LibLiquidation.sol";
 import "./lib/LibBalances.sol";
+import "./lib/LibPerpetuals.sol";
 import "./Interfaces/ILiquidation.sol";
 import "./Interfaces/ITrader.sol";
 import "./Interfaces/ITracerPerpetualSwaps.sol";
@@ -82,7 +83,7 @@ contract Liquidation is ILiquidation, Ownable {
         uint256 price,
         uint256 escrowedAmount,
         int256 amountLiquidated,
-        bool liquidationSide
+        Perpetuals.Side liquidationSide
     ) internal {
         liquidationReceipts[currentLiquidationId] = LibLiquidation
             .LiquidationReceipt(
@@ -148,9 +149,9 @@ contract Liquidation is ILiquidation, Ownable {
                 ITrader(traderContract).getOrder(orders[i]);
             if (
                 order.created < receipt.time || // Order made before receipt
-                order.maker != receipt.liquidator // Order made by someone who isn't liquidator
+                order.maker != receipt.liquidator || // Order made by someone who isn't liquidator
                 // todo alter liquidations side to be a Side type, then re add this comparison
-                // || order.side == receipt.liquidationSide // Order is in same direction as liquidation
+                order.side == receipt.liquidationSide // Order is in same direction as liquidation
                 /* Order should be the opposite to the position acquired on liquidation */
             ) {
                 emit InvalidClaimOrder(receiptId, receipt.liquidator);
@@ -232,7 +233,8 @@ contract Liquidation is ILiquidation, Ownable {
             );
 
         // create a liquidation receipt
-        bool side = base < 0 ? false : true;
+        Perpetuals.Side side =
+            base < 0 ? Perpetuals.Side.Short : Perpetuals.Side.Long;
         submitLiquidation(
             msg.sender,
             account,

--- a/contracts/test/LibLiquidationMock.sol
+++ b/contracts/test/LibLiquidationMock.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../lib/LibLiquidation.sol";
+import "../lib/LibPerpetuals.sol";
 
 library LibLiquidationMock {
     function calcEscrowLiquidationAmount(
@@ -45,7 +46,7 @@ library LibLiquidationMock {
         uint256 maxSlippage,
         uint256 avgPrice,
         uint256 receiptPrice,
-        bool receiptSide
+        uint256 receiptSide
     ) external pure returns (uint256 result) {
         /* Create a struct LibLiquidation with only price and liquidationSide set,
            as they are the only ones used in calculateSlippage */
@@ -60,7 +61,7 @@ library LibLiquidationMock {
                 0,
                 0,
                 false, // Not used
-                receiptSide,
+                Perpetuals.Side(receiptSide),
                 false // Not used
             );
 

--- a/deploy/DeployMocks.js
+++ b/deploy/DeployMocks.js
@@ -4,9 +4,17 @@ module.exports = async function (hre) {
 
     const { deployer } = await getNamedAccounts()
 
+    const libPerpetuals = await deploy("Perpetuals", {
+        from: deployer,
+        log: true,
+    })
+
     const libLiquidation = await deploy("LibLiquidation", {
         from: deployer,
         log: true,
+        libraries: {
+            Perpetuals: libPerpetuals.address,
+        },
     })
 
     await deploy("LibLiquidationMock", {
@@ -14,6 +22,7 @@ module.exports = async function (hre) {
         log: true,
         libraries: {
             LibLiquidation: libLiquidation.address,
+            Perpetuals: libPerpetuals.address,
         },
     })
 }

--- a/deploy/FullDeploy.js
+++ b/deploy/FullDeploy.js
@@ -226,6 +226,7 @@ module.exports = async function (hre) {
             LibMath: libMath.address,
             Balances: libBalances.address,
             LibLiquidation: libLiquidation.address,
+            Perpetuals: libPerpetuals.address,
         },
     })
 

--- a/test/unit/LibLiquidation.js
+++ b/test/unit/LibLiquidation.js
@@ -4,8 +4,8 @@ const { ethers, getNamedAccounts, deployments } = require("hardhat")
 describe("Unit tests: LibLiquidation.sol", function () {
     let libLiquidation
     let accounts
-    const long = true
-    const short = false
+    const long = 0
+    const short = 1
 
     before(async function () {
         await deployments.fixture(["LibLiquidationMock"])


### PR DESCRIPTION
### Motivation
Now that we are using an `Enum` to tell which side an order is (long vs short), we should use this in `LibLiquidation.LiquidationReceipt`

### Changes
- Switched all references to `liquidationSide` to use the `Enum Side` in `LibPerpetuals.sol`