### PR TITLE
Consistent withdraw and deposit

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -49,11 +49,11 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     }
 
     /**
-     * @notice Allows a user to stake to a given tracer market insurance pool
+     * @notice Allows a user to deposit to a given tracer market insurance pool
      * @dev Mints amount of the pool token to the user
      * @param amount the amount of tokens to stake. Provided in WAD format
      */
-    function stake(uint256 amount) external override {
+    function deposit(uint256 amount) external override {
         IERC20 collateralToken = IERC20(collateralAsset);
         collateralToken.transferFrom(msg.sender, address(this), amount);
 

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -62,7 +62,8 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
         collateralToken.transferFrom(msg.sender, address(this), rawTokenAmount);
 
         // amount in wad format after being converted from token format
-        uint256 wadAmount = uint(Balances.tokenToWad(quoteTokenDecimals, rawTokenAmount));
+        uint256 wadAmount =
+            uint256(Balances.tokenToWad(quoteTokenDecimals, rawTokenAmount));
         // Update pool balances and user
         updatePoolAmount();
         InsurancePoolToken poolToken = InsurancePoolToken(token);

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -51,7 +51,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     /**
      * @notice Allows a user to stake to a given tracer market insurance pool
      * @dev Mints amount of the pool token to the user
-     * @param amount the amount of tokens to stake. Provided in token native units
+     * @param amount the amount of tokens to stake. Provided in WAD format
      */
     function stake(uint256 amount) external override {
         IERC20 collateralToken = IERC20(collateralAsset);
@@ -59,7 +59,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
 
         // convert token amount to WAD
         uint256 amountToUpdate =
-            uint256(Balances.tokenToWad(tracer.quoteTokenDecimals(), amount));
+            Balances.wadToToken(tracer.quoteTokenDecimals(), amount);
 
         // Update pool balances and user
         updatePoolAmount();

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -57,12 +57,12 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
         IERC20 collateralToken = IERC20(collateralAsset);
         // convert token amount to WAD
         uint256 quoteTokenDecimals = tracer.quoteTokenDecimals();
-        uint256 amountToUpdate =
+        uint256 rawTokenAmount =
             Balances.wadToToken(quoteTokenDecimals, amount);
-        collateralToken.transferFrom(msg.sender, address(this), amountToUpdate);
+        collateralToken.transferFrom(msg.sender, address(this), rawTokenAmount);
 
         // amount in wad format after being converted from token format
-        uint256 _amount = uint(Balances.tokenToWad(quoteTokenDecimals, amountToUpdate));
+        uint256 wadAmount = uint(Balances.tokenToWad(quoteTokenDecimals, rawTokenAmount));
         // Update pool balances and user
         updatePoolAmount();
         InsurancePoolToken poolToken = InsurancePoolToken(token);
@@ -72,13 +72,13 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
             LibInsurance.calcMintAmount(
                 poolToken.totalSupply(),
                 collateralAmount,
-                _amount
+                wadAmount
             );
 
         // mint pool tokens, hold collateral tokens
         poolToken.mint(msg.sender, tokensToMint);
-        collateralAmount = collateralAmount + _amount;
-        emit InsuranceDeposit(address(tracer), msg.sender, _amount);
+        collateralAmount = collateralAmount + wadAmount;
+        emit InsuranceDeposit(address(tracer), msg.sender, wadAmount);
     }
 
     /**
@@ -103,12 +103,12 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
             );
 
         // convert token amount to raw amount from WAD
-        uint256 tokensToSend =
+        uint256 rawTokenAmount =
             Balances.wadToToken(tracer.quoteTokenDecimals(), wadTokensToSend);
 
         // burn pool tokens, return collateral tokens
         poolToken.burnFrom(msg.sender, amount);
-        collateralToken.transfer(msg.sender, tokensToSend);
+        collateralToken.transfer(msg.sender, rawTokenAmount);
 
         // pool amount is always in WAD format
         collateralAmount = collateralAmount - wadTokensToSend;

--- a/contracts/Interfaces/IInsurance.sol
+++ b/contracts/Interfaces/IInsurance.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 interface IInsurance {
-    function stake(uint256 amount) external;
+    function deposit(uint256 amount) external;
 
     function withdraw(uint256 amount) external;
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -123,7 +123,7 @@ contract TracerPerpetualSwaps is
         _updateAccountLeverage(msg.sender);
 
         // update market TVL
-        tvl = tvl + uint(convertedWadAmount);
+        tvl = tvl + uint256(convertedWadAmount);
         emit Deposit(msg.sender, amount);
     }
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -104,7 +104,7 @@ contract TracerPerpetualSwaps is
         // cast is safe since amount is a uint, and wadToToken can only
         // scale down the value
         uint256 amountToTransfer =
-            uint(Balances.wadToToken(quoteTokenDecimals, amount).toInt256());
+            uint256(Balances.wadToToken(quoteTokenDecimals, amount).toInt256());
         IERC20(tracerQuoteToken).transferFrom(
             msg.sender,
             address(this),
@@ -113,8 +113,9 @@ contract TracerPerpetualSwaps is
 
         // this prevents dust from being added to the user account
         // eg 10^18 -> 10^8 -> 10^18 will remove lower order bits
-        int256 amountFormatted = Balances.tokenToWad(quoteTokenDecimals, amountToTransfer);
-        
+        int256 amountFormatted =
+            Balances.tokenToWad(quoteTokenDecimals, amountToTransfer);
+
         // update user state
         userBalance.position.quote =
             userBalance.position.quote +

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -103,27 +103,27 @@ contract TracerPerpetualSwaps is
         // convert the WAD amount to the correct token amount to transfer
         // cast is safe since amount is a uint, and wadToToken can only
         // scale down the value
-        uint256 amountToTransfer =
+        uint256 rawTokenAmount =
             uint256(Balances.wadToToken(quoteTokenDecimals, amount).toInt256());
         IERC20(tracerQuoteToken).transferFrom(
             msg.sender,
             address(this),
-            amountToTransfer
+            rawTokenAmount
         );
 
         // this prevents dust from being added to the user account
         // eg 10^18 -> 10^8 -> 10^18 will remove lower order bits
-        int256 amountFormatted =
-            Balances.tokenToWad(quoteTokenDecimals, amountToTransfer);
+        int256 convertedWadAmount =
+            Balances.tokenToWad(quoteTokenDecimals, rawTokenAmount);
 
         // update user state
         userBalance.position.quote =
             userBalance.position.quote +
-            amountFormatted;
+            convertedWadAmount;
         _updateAccountLeverage(msg.sender);
 
         // update market TVL
-        tvl = tvl + amount;
+        tvl = tvl + uint(convertedWadAmount);
         emit Deposit(msg.sender, amount);
     }
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -95,7 +95,7 @@ contract TracerPerpetualSwaps is
      * @notice Allows a user to deposit into their margin account
      * @dev this contract must be an approved spender of the markets quote token on behalf of the depositer.
      * @param amount The amount of quote tokens to be deposited into the Tracer Market account. This amount
-     * should be given with the correct decimal units of the token
+     * should be given in WAD format.
      */
     function deposit(uint256 amount) external override {
         Balances.Account storage userBalance = balances[msg.sender];
@@ -106,14 +106,14 @@ contract TracerPerpetualSwaps is
         );
 
         // update user state
-        int256 amountToUpdate = Balances.tokenToWad(quoteTokenDecimals, amount);
+        int256 amountToUpdate = Balances.wadToToken(quoteTokenDecimals, amount).toInt256();
         userBalance.position.quote =
             userBalance.position.quote +
             amountToUpdate;
         _updateAccountLeverage(msg.sender);
 
         // update market TVL
-        // this cast is safe since amount > 0 on deposit and tokenToWad simply
+        // this cast is safe since amount > 0 on deposit and wadToToken simply
         // multiplies the amount up to a WAD value
         tvl = tvl + uint256(amountToUpdate);
         emit Deposit(msg.sender, amount);

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -106,7 +106,8 @@ contract TracerPerpetualSwaps is
         );
 
         // update user state
-        int256 amountToUpdate = Balances.wadToToken(quoteTokenDecimals, amount).toInt256();
+        int256 amountToUpdate =
+            Balances.wadToToken(quoteTokenDecimals, amount).toInt256();
         userBalance.position.quote =
             userBalance.position.quote +
             amountToUpdate;

--- a/test/unit/Insurance.js
+++ b/test/unit/Insurance.js
@@ -122,11 +122,11 @@ describe("Unit tests: Insurance.sol", function () {
         })
     })
 
-    describe("stake", async () => {
+    describe("deposit", async () => {
         context("when the user does not have enough tokens", async () => {
             it("reverts", async () => {
                 await expect(
-                    insurance.stake(ethers.utils.parseEther("1"))
+                    insurance.deposit(ethers.utils.parseEther("1"))
                 ).to.be.revertedWith("ERC20: transfer amount exceeds allowance")
             })
         })
@@ -137,7 +137,7 @@ describe("Unit tests: Insurance.sol", function () {
                     insurance.address,
                     ethers.utils.parseEther("1")
                 )
-                await insurance.stake(ethers.utils.parseEther("1"))
+                await insurance.deposit(ethers.utils.parseEther("1"))
             })
 
             it("mints them pool tokens", async () => {
@@ -177,7 +177,7 @@ describe("Unit tests: Insurance.sol", function () {
                     insurance.address,
                     ethers.utils.parseEther("2")
                 )
-                await insurance.stake(ethers.utils.parseEther("2"))
+                await insurance.deposit(ethers.utils.parseEther("2"))
                 // get user to burn some pool tokens
                 await insurance.withdraw(ethers.utils.parseEther("1"))
             })
@@ -284,7 +284,7 @@ describe("Unit tests: Insurance.sol", function () {
                     insurance.address,
                     ethers.utils.parseEther("5")
                 )
-                await insurance.stake(ethers.utils.parseEther("5"))
+                await insurance.deposit(ethers.utils.parseEther("5"))
 
                 // try withdraw 10 from the pool
                 let collateralAmountPre = await insurance.collateralAmount()
@@ -303,7 +303,7 @@ describe("Unit tests: Insurance.sol", function () {
                     insurance.address,
                     ethers.utils.parseEther("5")
                 )
-                await insurance.stake(ethers.utils.parseEther("5"))
+                await insurance.deposit(ethers.utils.parseEther("5"))
 
                 // try withdraw 10 from the pool
                 let collateralAmountPre = await insurance.collateralAmount()
@@ -321,7 +321,7 @@ describe("Unit tests: Insurance.sol", function () {
                     insurance.address,
                     ethers.utils.parseEther("5")
                 )
-                await insurance.stake(ethers.utils.parseEther("5"))
+                await insurance.deposit(ethers.utils.parseEther("5"))
 
                 // try withdraw 10 from the pool
                 await insurance.drainPool(ethers.utils.parseEther("1"))
@@ -333,7 +333,7 @@ describe("Unit tests: Insurance.sol", function () {
                     insurance.address,
                     ethers.utils.parseEther("5")
                 )
-                await insurance.stake(ethers.utils.parseEther("5"))
+                await insurance.deposit(ethers.utils.parseEther("5"))
 
                 // withdraw from pool
                 await insurance.drainPool(ethers.utils.parseEther("2"))
@@ -361,7 +361,7 @@ describe("Unit tests: Insurance.sol", function () {
                     insurance.address,
                     ethers.utils.parseEther("2")
                 )
-                await insurance.stake(ethers.utils.parseEther("2"))
+                await insurance.deposit(ethers.utils.parseEther("2"))
                 let poolBalance = await insurance.getPoolUserBalance(
                     accounts[0].address
                 )


### PR DESCRIPTION
# Motivation
Previously deposit took in `amount` as a raw token amount, and withdraw as a WAD amount. To keep this consistent, these have all been changed to WAD amounts.

# Changes
- change `amount` on deposit to be a WAD
- rename `stake` to `deposit` on `insurance.sol`