### PR TITLE
Margin is valid with no base

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -453,13 +453,10 @@ contract TracerPerpetualSwaps is
             Balances.minimumMargin(pos, price, gasCost, maxLeverage);
         int256 margin = Balances.margin(pos, price);
 
-        if (margin < 0) {
-            /* Margin being less than 0 is always invalid, even if position is 0.
-               This could happen if user attempts to over-withdraw */
-            return false;
-        }
         if (minMargin == 0) {
-            return true;
+            // minMargin = 0 only occurs when user has no base (positions)
+            // if they have no base, their quote must be > 0.
+            return quote >= 0;
         }
 
         // todo CASTING CHECK

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -460,6 +460,12 @@ contract TracerPerpetualSwaps is
         uint256 minMargin =
             Balances.minimumMargin(pos, price, gasCost, maxLeverage);
         int256 margin = Balances.margin(pos, price);
+        
+        if (margin < 0) {
+            /* Margin being less than 0 is always invalid, even if position is 0.
+               This could happen if user attempts to over-withdraw */
+            return false;
+        }
 
         if (minMargin == 0) {
             // minMargin = 0 only occurs when user has no base (positions)

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -482,7 +482,7 @@ contract TracerPerpetualSwaps is
         uint256 minMargin =
             Balances.minimumMargin(pos, price, gasCost, maxLeverage);
         int256 margin = Balances.margin(pos, price);
-        
+
         if (margin < 0) {
             /* Margin being less than 0 is always invalid, even if position is 0.
                This could happen if user attempts to over-withdraw */


### PR DESCRIPTION
# Motivation
There was a bug with how withdraw was computing `marginIsValid`. This allowed a user to withdraw more than deposited when they had no base (positions) outstanding.

# Changes
- ensure quote > 0 if base = 0 in `marginIsValid`
- removes redundant `margin < 0` check