### PR TITLE
Make grabOrder return memory & rearrange LibPerpetuals.orderId signature

### DIFF
--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -87,8 +87,8 @@ contract Trader is ITrader {
 
             // retrieve orders
             // if the order does not exist, it is created here
-            Perpetuals.Order storage makeOrder = grabOrder(makers, i);
-            Perpetuals.Order storage takeOrder = grabOrder(takers, i);
+            Perpetuals.Order memory makeOrder = grabOrder(makers, i);
+            Perpetuals.Order memory takeOrder = grabOrder(takers, i);
 
             uint256 makeOrderFilled = filled[Perpetuals.orderId(makeOrder)];
             uint256 takeOrderFilled = filled[Perpetuals.orderId(takeOrder)];
@@ -139,7 +139,7 @@ contract Trader is ITrader {
     function grabOrder(
         Types.SignedLimitOrder[] memory signedOrders,
         uint256 index
-    ) internal returns (Perpetuals.Order storage) {
+    ) internal returns (Perpetuals.Order memory) {
         Perpetuals.Order memory rawOrder = signedOrders[index].order;
 
         bytes32 orderHash = Perpetuals.orderId(rawOrder);
@@ -245,7 +245,7 @@ contract Trader is ITrader {
      * @return An order that has been previously created in contract, given a user-supplied order
      * @dev Useful for checking to see if a supplied order has actually been created
      */
-    function getOrder(Perpetuals.Order memory order)
+    function getOrder(Perpetuals.Order calldata order)
         public
         view
         override

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -14,7 +14,7 @@ library Perpetuals {
         uint256 created;
     }
 
-    function orderId(Order calldata order) public pure returns (bytes32) {
+    function orderId(Order memory order) internal pure returns (bytes32) {
         return keccak256(abi.encode(order));
     }
 

--- a/contracts/test/LibPerpetualsMock.sol
+++ b/contracts/test/LibPerpetualsMock.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.8.0;
 
 import "../lib/LibPerpetuals.sol";
 
-contract LibPerpetualsMock {
+contract PerpetualsMock {
     function orderId(Perpetuals.Order memory order) external returns (bytes32) {
         return Perpetuals.orderId(order);
     }

--- a/contracts/test/LibPerpetualsMock.sol
+++ b/contracts/test/LibPerpetualsMock.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.8.0;
 import "../lib/LibPerpetuals.sol";
 
 contract LibPerpetualsMock {
+    function orderId(Perpetuals.Order memory order) external returns (bytes32) {
+        return Perpetuals.orderId(order);
+    }
+
     function canMatch(
         Perpetuals.Order calldata a,
         uint256 aFilled,

--- a/test/unit/LibPerpetuals.js
+++ b/test/unit/LibPerpetuals.js
@@ -15,7 +15,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
             log: true,
         })
 
-        await deploy("LibPerpetualsMock", {
+        await deploy("PerpetualsMock", {
             from: deployer,
             log: true,
             libraries: {
@@ -23,7 +23,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
             },
         })
 
-        let deployment = await deployments.get("LibPerpetualsMock")
+        let deployment = await deployments.get("PerpetualsMock")
         libPerpetuals = await ethers.getContractAt(
             deployment.abi,
             deployment.address


### PR DESCRIPTION
### Motivation
grabOrder returns a storage struct. But given that it's not actually modified (Order types  are now immutable), it should copy it straight to memory for gas savings.

Also, while writing tests on a separate branch, I had some issues with getting getOrder to work and found that with some rearranging it was able to be fixed.

### Changes
- Make `Trader.grabOrder(...)` return memory struct, not storage
- Make `Perpetuals.orderId(...)` take memory struct, and make it internal
- Add orderId to LibPerpetualsMock
- Change contract name `libPerpetualsMock -> PerpetualsMock` to be consistent with `Perpetuals`.