### PR TITLE
Added check for order price in calcUnitsSold

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -158,19 +158,19 @@ contract Liquidation is ILiquidation, Ownable {
             }
 
             if (
-                receipt.liquidationSide == Perpetuals.Side.Short &&
+                receipt.liquidationSide == Perpetuals.Side.Long &&
                 order.price >= receipt.price
             ) {
-                // The order is short -> Liquidation position was long
+                // Liquidation position was long
                 // Price went up, so not a slippage order
                 emit InvalidClaimOrder(receiptId, receipt.liquidator);
                 continue;
             }
             if (
-                receipt.liquidationSide == Perpetuals.Side.Long &&
+                receipt.liquidationSide == Perpetuals.Side.Short &&
                 order.price <= receipt.price
             ) {
-                // The order is long -> Liquidation position was short
+                // Liquidation position was short
                 // Price went down, so not a slippage order
                 emit InvalidClaimOrder(receiptId, receipt.liquidator);
                 continue;

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -157,6 +157,24 @@ contract Liquidation is ILiquidation, Ownable {
                 continue;
             }
 
+            if (
+                order.side == Perpetuals.Side.Short &&
+                order.price >= receipt.price
+            ) {
+                // The order is short -> Liquidation position was long
+                // Price went up, so not a slippage order
+                emit InvalidClaimOrder(receiptId, receipt.liquidator);
+                continue;
+            }
+            if (
+                order.side == Perpetuals.Side.Long &&
+                order.price <= receipt.price
+            ) {
+                // The order is long -> Liquidation position was short
+                // Price went down, so not a slippage order
+                emit InvalidClaimOrder(receiptId, receipt.liquidator);
+                continue;
+            }
             uint256 orderFilled = ITrader(traderContract).filledAmount(order);
 
             /* order.created >= receipt.time

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -158,7 +158,7 @@ contract Liquidation is ILiquidation, Ownable {
             }
 
             if (
-                order.side == Perpetuals.Side.Short &&
+                receipt.liquidationSide == Perpetuals.Side.Short &&
                 order.price >= receipt.price
             ) {
                 // The order is short -> Liquidation position was long
@@ -167,7 +167,7 @@ contract Liquidation is ILiquidation, Ownable {
                 continue;
             }
             if (
-                order.side == Perpetuals.Side.Long &&
+                receipt.liquidationSide == Perpetuals.Side.Long &&
                 order.price <= receipt.price
             ) {
                 // The order is long -> Liquidation position was short

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -158,18 +158,14 @@ contract Liquidation is ILiquidation, Ownable {
             }
 
             if (
-                receipt.liquidationSide == Perpetuals.Side.Long &&
-                order.price >= receipt.price
+                (receipt.liquidationSide == Perpetuals.Side.Long &&
+                    order.price >= receipt.price) ||
+                (receipt.liquidationSide == Perpetuals.Side.Short &&
+                    order.price <= receipt.price)
             ) {
                 // Liquidation position was long
                 // Price went up, so not a slippage order
-                emit InvalidClaimOrder(receiptId, receipt.liquidator);
-                continue;
-            }
-            if (
-                receipt.liquidationSide == Perpetuals.Side.Short &&
-                order.price <= receipt.price
-            ) {
+                // or
                 // Liquidation position was short
                 // Price went down, so not a slippage order
                 emit InvalidClaimOrder(receiptId, receipt.liquidator);


### PR DESCRIPTION
### Motivation
If an order is given during slippage submit, and the order has negative slippage (price up when liquidation was long, vise-versa), then it should be ignored

### Changes
- Ignore orders that had negative slippage on calcUnitsSold