### PR TITLE
Mark `LibBalances` functions as internal

### DIFF
--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -34,7 +34,7 @@ library Balances {
     }
 
     function netValue(Position memory position, uint256 price)
-        public
+        internal
         pure
         returns (uint256)
     {
@@ -48,7 +48,7 @@ library Balances {
      * @param price The price of the base asset
      */
     function margin(Position memory position, uint256 price)
-        public
+        internal
         pure
         returns (int256)
     {
@@ -74,7 +74,7 @@ library Balances {
      * @param price The price of the base asset
      */
     function leveragedNotionalValue(Position memory position, uint256 price)
-        public
+        internal
         pure
         returns (uint256)
     {
@@ -95,7 +95,7 @@ library Balances {
         uint256 price,
         uint256 liquidationCost,
         uint256 maximumLeverage
-    ) public pure returns (uint256) {
+    ) internal pure returns (uint256) {
         // There should be no Minimum margin when user has no position
         if (position.base == 0) {
             return 0;

--- a/test/unit/Insurance.js
+++ b/test/unit/Insurance.js
@@ -35,7 +35,6 @@ const setup = deployments.createFixture(async () => {
         "TracerPerpetualSwaps",
         {
             libraries: {
-                Balances: libBalances.address,
                 Perpetuals: libPerpetuals.address,
                 Prices: libPrices.address,
             },


### PR DESCRIPTION
# Motivation
Library functions should be `internal`.

# Changes
 - Change the visibility of all functions in the `LibBalances` library from `public` to `internal`
 - Remove explicit linking from `Insurance.sol` tests
