### PR TITLE
Remove instances of boolean side representation

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -48,7 +48,7 @@ contract Liquidation is ILiquidation, Ownable {
         address indexed account,
         address indexed liquidator,
         int256 liquidationAmount,
-        bool side,
+        Perpetuals.Side side,
         address indexed market,
         uint256 liquidationId
     );
@@ -291,7 +291,11 @@ contract Liquidation is ILiquidation, Ownable {
             account,
             msg.sender,
             amount,
-            (liquidatedBalance.position.base < 0 ? false : true),
+            (
+                liquidatedBalance.position.base < 0
+                    ? Perpetuals.Side.Short
+                    : Perpetuals.Side.Long
+            ),
             address(tracer),
             currentLiquidationId - 1
         );


### PR DESCRIPTION
# Motivation
Market sides have a dedicated enumerated type now -- we should use them.

# Changes
 - Change liquidation events to use the `Perpetuals.Side` type
