### PR TITLE
Balances.Trade's amount field is the fillAmount, rather than order amount

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -233,39 +233,29 @@ contract TracerPerpetualSwaps is
         Balances.Account storage account1 = balances[order1.maker];
         Balances.Account storage account2 = balances[order2.maker];
 
-        // Construct `Trade` types suitable for use with LibBalances
-        (Balances.Trade memory trade1, Balances.Trade memory trade2) =
-            (
-                Balances.Trade(order1.price, order1.amount, order1.side),
-                Balances.Trade(order2.price, order2.amount, order2.side)
-            );
-
         bytes32 orderId1 = Perpetuals.orderId(order1);
         bytes32 orderId2 = Perpetuals.orderId(order2);
 
         uint256 fillAmount =
             Balances.fillAmount(
-                trade1,
+                order1,
                 filled[orderId1],
-                trade2,
+                order2,
                 filled[orderId2]
+            );
+
+        // Construct `Trade` types suitable for use with LibBalances
+        (Balances.Trade memory trade1, Balances.Trade memory trade2) =
+            (
+                Balances.Trade(order1.price, fillAmount, order1.side),
+                Balances.Trade(order2.price, fillAmount, order2.side)
             );
 
         // Calculate new account state
         (Balances.Position memory newPos1, Balances.Position memory newPos2) =
             (
-                Balances.applyTrade(
-                    account1.position,
-                    trade1,
-                    fillAmount,
-                    feeRate
-                ),
-                Balances.applyTrade(
-                    account2.position,
-                    trade2,
-                    fillAmount,
-                    feeRate
-                )
+                Balances.applyTrade(account1.position, trade1, feeRate),
+                Balances.applyTrade(account2.position, trade2, feeRate)
             );
 
         // Update account state with results of above calculation

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -117,22 +117,19 @@ library Balances {
     }
 
     function fillAmount(
-        Trade memory tradeA,
+        Perpetuals.Order memory orderA,
         uint256 fillA,
-        Trade memory tradeB,
+        Perpetuals.Order memory orderB,
         uint256 fillB
     ) internal pure returns (uint256) {
-        return LibMath.min(tradeA.amount - fillA, tradeB.amount - fillB);
+        return LibMath.min(orderA.amount - fillA, orderB.amount - fillB);
     }
 
     function applyTrade(
         Position memory position,
         Trade memory trade,
-        uint256 fill,
         uint256 feeRate
     ) internal pure returns (Position memory) {
-        require(fill <= trade.amount);
-
         int256 signedAmount = LibMath.toInt256(trade.amount);
         int256 signedPrice = LibMath.toInt256(trade.price);
         int256 signedFeeRate = LibMath.toInt256(feeRate);


### PR DESCRIPTION
### Motivation
We decided it would be cleaner to have `Balances.Trade.amount` be set to the fill amount of a trade, rather than the whole order's amount.

### Changes
- Make `Balances.fillAmount` take order instead of trade
- Change Trades to take fillAMount instead of Order.amount
- Remove `fill` parameter from `Balances.applyTrade`