### PR TITLE
Deleveraging v2

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -21,7 +21,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     ITracerPerpetualsFactory public perpsFactory;
 
     address public collateralAsset; // Address of collateral asset
-    uint256 public collateralAmount; // amount of underlying collateral in pool, in WAD format
+    uint256 public override collateralAmount; // amount of underlying collateral in pool, in WAD format
     address public token; // token representation of a users holding in the pool
 
     ITracerPerpetualSwaps public tracer; // Tracer associated with Insurance Pool

--- a/contracts/Interfaces/IInsurance.sol
+++ b/contracts/Interfaces/IInsurance.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.0;
 
 interface IInsurance {
+    function collateralAmount() external view returns (uint256);
+
     function deposit(uint256 amount) external;
 
     function withdraw(uint256 amount) external;

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -42,6 +42,8 @@ interface ITracerPerpetualSwaps {
 
     function maxLeverage() external view returns (uint256);
 
+    function trueMaxLeverage() external view returns (uint256);
+
     function LIQUIDATION_GAS_COST() external view returns (uint256);
 
     function fundingRateSensitivity() external view returns (uint256);

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -46,6 +46,10 @@ interface ITracerPerpetualSwaps {
 
     function fundingRateSensitivity() external view returns (uint256);
 
+    function deleveragingCliff() external view returns (uint256);
+
+    function lowestMaxLeverage() external view returns (uint256);
+
     function getBalance(address account)
         external
         view

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -78,6 +78,13 @@ interface ITracerPerpetualSwaps {
     function setFundingRateSensitivity(uint256 _fundingRateSensitivity)
         external;
 
+    function setDeleveragingCliff(uint256 _deleveragingCliff) external;
+
+    function setLowestMaxLeverage(uint256 _lowestMaxLeverage) external;
+
+    function setInsurancePoolSwitchStage(uint256 _insurancePoolSwitchStage)
+        external;
+
     function transferOwnership(address newOwner) external;
 
     function deposit(uint256 amount) external;

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -52,6 +52,8 @@ interface ITracerPerpetualSwaps {
 
     function lowestMaxLeverage() external view returns (uint256);
 
+    function insurancePoolSwitchStage() external view returns (uint256);
+
     function getBalance(address account)
         external
         view

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -599,6 +599,30 @@ contract TracerPerpetualSwaps is
         fundingRateSensitivity = _fundingRateSensitivity;
     }
 
+    function setDeleveragingCliff(uint256 _deleveragingCliff)
+        public
+        override
+        onlyOwner
+    {
+        deleveragingCliff = _deleveragingCliff;
+    }
+
+    function setLowestMaxLeverage(uint256 _lowestMaxLeverage)
+        public
+        override
+        onlyOwner
+    {
+        lowestMaxLeverage = _lowestMaxLeverage;
+    }
+
+    function setInsurancePoolSwitchStage(uint256 _insurancePoolSwitchStage)
+        public
+        override
+        onlyOwner
+    {
+        insurancePoolSwitchStage = _insurancePoolSwitchStage;
+    }
+
     function transferOwnership(address newOwner)
         public
         override(Ownable, ITracerPerpetualSwaps)

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -233,39 +233,29 @@ contract TracerPerpetualSwaps is
         Balances.Account storage account1 = balances[order1.maker];
         Balances.Account storage account2 = balances[order2.maker];
 
-        // Construct `Trade` types suitable for use with LibBalances
-        (Balances.Trade memory trade1, Balances.Trade memory trade2) =
-            (
-                Balances.Trade(order1.price, order1.amount, order1.side),
-                Balances.Trade(order2.price, order2.amount, order2.side)
-            );
-
         bytes32 orderId1 = Perpetuals.orderId(order1);
         bytes32 orderId2 = Perpetuals.orderId(order2);
 
         uint256 fillAmount =
             Balances.fillAmount(
-                trade1,
+                order1,
                 filled[orderId1],
-                trade2,
+                order2,
                 filled[orderId2]
+            );
+
+        // Construct `Trade` types suitable for use with LibBalances
+        (Balances.Trade memory trade1, Balances.Trade memory trade2) =
+            (
+                Balances.Trade(order1.price, fillAmount, order1.side),
+                Balances.Trade(order2.price, fillAmount, order2.side)
             );
 
         // Calculate new account state
         (Balances.Position memory newPos1, Balances.Position memory newPos2) =
             (
-                Balances.applyTrade(
-                    account1.position,
-                    trade1,
-                    fillAmount,
-                    feeRate
-                ),
-                Balances.applyTrade(
-                    account2.position,
-                    trade2,
-                    fillAmount,
-                    feeRate
-                )
+                Balances.applyTrade(account1.position, trade1, feeRate),
+                Balances.applyTrade(account2.position, trade2, feeRate)
             );
 
         // Update account state with results of above calculation

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -39,6 +39,7 @@ contract TracerPerpetualSwaps is
     address public feeReceiver;
 
     /* Config variables */
+    // The price of gas in gwei
     address public override gasPriceOracle;
     // The maximum ratio of notionalValue to margin
     uint256 public override maxLeverage;
@@ -46,6 +47,9 @@ contract TracerPerpetualSwaps is
     uint256 public override fundingRateSensitivity;
     // WAD value. The percentage for insurance pool holdings/pool target where deleveraging begins
     uint256 public override deleveragingCliff;
+    /* The percentage of insurance holdings to target at which the insurance pool
+       funding rate changes, and lowestMaxLeverage is reached */
+    uint256 public override insurancePoolSwitchStage;
     // The lowest value that maxLeverage can be, if insurance pool is empty.
     uint256 public override lowestMaxLeverage;
 
@@ -84,6 +88,8 @@ contract TracerPerpetualSwaps is
      * @param _deleveragingCliff The percentage for insurance pool holdings/pool target where deleveraging begins.
      *                           u60.18-decimal fixed-point number. e.g. 20% = 0.2*10^18
      * @param _lowestMaxLeverage The lowest value that maxLeverage can be, if insurance pool is empty.
+     * @param _insurancePoolSwitchStage The percentage of insurance holdings to target at which the insurance pool
+     *                                  funding rate changes, and lowestMaxLeverage is reached
      */
     constructor(
         bytes32 _marketId,
@@ -95,7 +101,8 @@ contract TracerPerpetualSwaps is
         uint256 _feeRate,
         address _feeReceiver,
         uint256 _deleveragingCliff,
-        uint256 _lowestMaxLeverage
+        uint256 _lowestMaxLeverage,
+        uint256 _insurancePoolSwitchStage
     ) Ownable() {
         // don't convert to interface as we don't need to interact with the contract
         tracerQuoteToken = _tracerQuoteToken;
@@ -108,6 +115,7 @@ contract TracerPerpetualSwaps is
         feeReceiver = _feeReceiver;
         deleveragingCliff = _deleveragingCliff;
         lowestMaxLeverage = _lowestMaxLeverage;
+        insurancePoolSwitchStage = _insurancePoolSwitchStage;
     }
 
     /**
@@ -122,7 +130,8 @@ contract TracerPerpetualSwaps is
                 insurance.getPoolTarget(),
                 maxLeverage,
                 lowestMaxLeverage,
-                deleveragingCliff
+                deleveragingCliff,
+                insurancePoolSwitchStage
             );
     }
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -86,7 +86,7 @@ contract TracerPerpetualSwaps is
      * @param _fundingRateSensitivity the affect funding rate changes have on funding paid.
      * @param _feeRate the fee taken on trades; u60.18-decimal fixed-point number. e.g. 2% fee = 0.02 * 10^18 = 2 * 10^16
      * @param _deleveragingCliff The percentage for insurance pool holdings/pool target where deleveraging begins.
-     *                           u60.18-decimal fixed-point number. e.g. 20% = 0.2*10^18
+     *                           u60.18-decimal fixed-point number. e.g. 20% = 20*10^18
      * @param _lowestMaxLeverage The lowest value that maxLeverage can be, if insurance pool is empty.
      * @param _insurancePoolSwitchStage The percentage of insurance holdings to target at which the insurance pool
      *                                  funding rate changes, and lowestMaxLeverage is reached

--- a/contracts/deployers/PerpsDeployerV1.sol
+++ b/contracts/deployers/PerpsDeployerV1.sol
@@ -16,11 +16,25 @@ contract PerpsDeployerV1 is IPerpsDeployer {
             address _gasPriceOracle,
             uint256 _maxLeverage,
             uint256 _fundingRateSensitivity,
-            uint256 _feeRate
+            uint256 _feeRate,
+            address _feeReceiver,
+            uint256 _deleveragingCliff,
+            uint256 _lowestMaxLeverage
         ) =
             abi.decode(
                 _data,
-                (bytes32, address, uint256, address, uint256, uint256, uint256)
+                (
+                    bytes32,
+                    address,
+                    uint256,
+                    address,
+                    uint256,
+                    uint256,
+                    uint256,
+                    address,
+                    uint256,
+                    uint256
+                )
             );
         TracerPerpetualSwaps tracer =
             new TracerPerpetualSwaps(
@@ -31,7 +45,9 @@ contract PerpsDeployerV1 is IPerpsDeployer {
                 _maxLeverage,
                 _fundingRateSensitivity,
                 _feeRate,
-                msg.sender
+                _feeReceiver,
+                _deleveragingCliff,
+                _lowestMaxLeverage
             );
         tracer.transferOwnership(msg.sender);
         return address(tracer);

--- a/contracts/deployers/PerpsDeployerV1.sol
+++ b/contracts/deployers/PerpsDeployerV1.sol
@@ -19,7 +19,8 @@ contract PerpsDeployerV1 is IPerpsDeployer {
             uint256 _feeRate,
             address _feeReceiver,
             uint256 _deleveragingCliff,
-            uint256 _lowestMaxLeverage
+            uint256 _lowestMaxLeverage,
+            uint256 _insurancePoolSwitchStage
         ) =
             abi.decode(
                 _data,
@@ -32,6 +33,7 @@ contract PerpsDeployerV1 is IPerpsDeployer {
                     uint256,
                     uint256,
                     address,
+                    uint256,
                     uint256,
                     uint256
                 )
@@ -47,7 +49,8 @@ contract PerpsDeployerV1 is IPerpsDeployer {
                 _feeRate,
                 _feeReceiver,
                 _deleveragingCliff,
-                _lowestMaxLeverage
+                _lowestMaxLeverage,
+                _insurancePoolSwitchStage
             );
         tracer.transferOwnership(msg.sender);
         return address(tracer);

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -117,22 +117,19 @@ library Balances {
     }
 
     function fillAmount(
-        Trade memory tradeA,
+        Perpetuals.Order memory orderA,
         uint256 fillA,
-        Trade memory tradeB,
+        Perpetuals.Order memory orderB,
         uint256 fillB
     ) internal pure returns (uint256) {
-        return LibMath.min(tradeA.amount - fillA, tradeB.amount - fillB);
+        return LibMath.min(orderA.amount - fillA, orderB.amount - fillB);
     }
 
     function applyTrade(
         Position memory position,
         Trade memory trade,
-        uint256 fill,
         uint256 feeRate
     ) internal pure returns (Position memory) {
-        require(fill <= trade.amount);
-
         int256 signedAmount = LibMath.toInt256(trade.amount);
         int256 signedPrice = LibMath.toInt256(trade.price);
         int256 signedFeeRate = LibMath.toInt256(feeRate);

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -1,5 +1,6 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
+import "prb-math/contracts/PRBMathUD60x18.sol";
 
 library Perpetuals {
     enum Side {Long, Short}
@@ -16,6 +17,43 @@ library Perpetuals {
 
     function orderId(Order memory order) internal pure returns (bytes32) {
         return keccak256(abi.encode(order));
+    }
+
+    function calculateTrueMaxLeverage(
+        uint256 collateralAmount,
+        uint256 poolTarget,
+        uint256 defaultMaxLeverage,
+        uint256 lowestMaxLeverage,
+        uint256 deleveragingCliff
+    ) internal pure returns (uint256) {
+        if (poolTarget == 0) {
+            return lowestMaxLeverage;
+        }
+        uint256 percentFull = PRBMathUD60x18.div(collateralAmount, poolTarget);
+
+        if (percentFull > deleveragingCliff) {
+            return defaultMaxLeverage;
+        }
+
+        // Linear function intercepting points (1, 0) and (INSURANCE_DELEVERAGING_CLIFF, defaultMaxLeverage)
+        // Where the x axis is how full the insurance pool is as a percentage,
+        // and the y axis is max leverage.
+        // y = mx + b,
+        // where m = (x2 - x1) / (y2 - y1) = (defaultMaxLeverage - lowestMaxLeverage)/(DELEVERAGING_CLIFF - 0)
+        //       x = percentFull
+        //       b = lowestMaxLeverage (since lowestMaxLeverage is the y-intercept)
+        // m was reached as that is the formula for calculating the gradient of a linear function
+        // (defaultMaxLeverage - LowestMaxLeverage)/cliff * percentFull + lowestMaxLeverage
+
+        uint256 maxLeverageDifference = defaultMaxLeverage - lowestMaxLeverage;
+        uint256 maxLeverageNotBumped =
+            PRBMathUD60x18.mul(
+                PRBMathUD60x18.div(maxLeverageDifference, deleveragingCliff),
+                percentFull
+            );
+        uint256 realMaxLeverage = maxLeverageNotBumped + lowestMaxLeverage;
+
+        return realMaxLeverage;
     }
 
     function canMatch(

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -66,7 +66,8 @@ library Perpetuals {
         //         = (defaultMaxLeverage - lowestMaxLeverage)/
         //           (DELEVERAGING_CLIFF - insurancePoolSwitchStage)
         //       x = percentFull
-        //       b = lowestMaxLeverage (since lowestMaxLeverage is the y-intercept)
+        //       b = lowestMaxLeverage -
+        //           ((defaultMaxLeverage - lowestMaxLeverage) / (deleveragingCliff - insurancePoolSwitchStage))
         // m was reached as that is the formula for calculating the gradient of a linear function
         // (defaultMaxLeverage - LowestMaxLeverage)/cliff * percentFull + lowestMaxLeverage
 

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -19,6 +19,18 @@ library Perpetuals {
         return keccak256(abi.encode(order));
     }
 
+    /**
+     * TODO Test in E2E context
+     * @notice Calculate the max leverage based on how full the insurance pool is
+     * @param collateralAmount Amount of collateral in insurance pool
+     * @param poolTarget Insurance target
+     * @param defaultMaxLeverage The max leverage assuming pool is sufficiently full
+     * @param lowestMaxLeverage The lowest that max leverage can ever drop to
+     * @param deleveragingCliff The point of insurance pool full-ness,
+              below which deleveraging begins
+     * @param insurancePoolSwitchStage The point of insurance pool full-ness,
+              at or below which the insurance pool switches funding rate mechanism
+     */
     function calculateTrueMaxLeverage(
         uint256 collateralAmount,
         uint256 poolTarget,

--- a/contracts/test/LibPerpetualsMock.sol
+++ b/contracts/test/LibPerpetualsMock.sol
@@ -12,7 +12,8 @@ contract PerpetualsMock {
         uint256 poolTarget,
         uint256 baseMaxLeverage,
         uint256 lowestMaxLeverage,
-        uint256 deleveragingCliff
+        uint256 deleveragingCliff,
+        uint256 insurancePoolSwitchStage
     ) external pure returns (uint256) {
         return
             Perpetuals.calculateTrueMaxLeverage(
@@ -20,7 +21,8 @@ contract PerpetualsMock {
                 poolTarget,
                 baseMaxLeverage,
                 lowestMaxLeverage,
-                deleveragingCliff
+                deleveragingCliff,
+                insurancePoolSwitchStage
             );
     }
 

--- a/contracts/test/LibPerpetualsMock.sol
+++ b/contracts/test/LibPerpetualsMock.sol
@@ -7,6 +7,23 @@ contract PerpetualsMock {
         return Perpetuals.orderId(order);
     }
 
+    function calculateTrueMaxLeverage(
+        uint256 collateralAmount,
+        uint256 poolTarget,
+        uint256 baseMaxLeverage,
+        uint256 lowestMaxLeverage,
+        uint256 deleveragingCliff
+    ) external pure returns (uint256) {
+        return
+            Perpetuals.calculateTrueMaxLeverage(
+                collateralAmount,
+                poolTarget,
+                baseMaxLeverage,
+                lowestMaxLeverage,
+                deleveragingCliff
+            );
+    }
+
     function canMatch(
         Perpetuals.Order calldata a,
         uint256 aFilled,

--- a/deploy/FullDeploy.js
+++ b/deploy/FullDeploy.js
@@ -200,9 +200,9 @@ module.exports = async function (hre) {
     let feeRate = 0 // 0 percent
     let fundingRateSensitivity = 1
     let maxLiquidationSlippage = ethers.utils.parseEther("50") // 50 percent
-    let deleveragingCliff = ethers.utils.parseEther("0.2") // 20 percent
+    let deleveragingCliff = ethers.utils.parseEther("20") // 20 percent
     let lowestMaxLeverage = ethers.utils.parseEther("12.5") // Default -> Doesn't go down
-    let _insurancePoolSwitchStage = ethers.utils.parseEther("0.01") // Switches mode at 1%
+    let _insurancePoolSwitchStage = ethers.utils.parseEther("1") // Switches mode at 1%
 
     var deployTracerData = ethers.utils.defaultAbiCoder.encode(
         [

--- a/deploy/FullDeploy.js
+++ b/deploy/FullDeploy.js
@@ -210,7 +210,9 @@ module.exports = async function (hre) {
             "uint256", //_maxLeverage,
             "uint256", //_fundingRateSensitivity,
             "uint256", //_feeRate
-            "address", // _feeReceiver
+            "address", // _feeReceiver,
+            "uint256", // _deleveragingCliff
+            "uint256", // _lowestMaxLeverage
         ],
         [
             ethers.utils.formatBytes32String("TEST1/USD"),
@@ -221,6 +223,8 @@ module.exports = async function (hre) {
             fundingRateSensitivity,
             feeRate,
             deployer,
+            ethers.utils.parseEther("0.2"), // 20 percent
+            ethers.utils.parseEther("2"),
         ]
     )
 

--- a/deploy/FullDeploy.js
+++ b/deploy/FullDeploy.js
@@ -202,6 +202,7 @@ module.exports = async function (hre) {
     let maxLiquidationSlippage = ethers.utils.parseEther("50") // 50 percent
     let deleveragingCliff = ethers.utils.parseEther("0.2") // 20 percent
     let lowestMaxLeverage = ethers.utils.parseEther("12.5") // Default -> Doesn't go down
+    let _insurancePoolSwitchStage = ethers.utils.parseEther("0.01") // Switches mode at 1%
 
     var deployTracerData = ethers.utils.defaultAbiCoder.encode(
         [
@@ -215,6 +216,7 @@ module.exports = async function (hre) {
             "address", // _feeReceiver,
             "uint256", // _deleveragingCliff
             "uint256", // _lowestMaxLeverage
+            "uint256", // _insurancePoolSwitchStage
         ],
         [
             ethers.utils.formatBytes32String("TEST1/USD"),
@@ -227,6 +229,7 @@ module.exports = async function (hre) {
             deployer,
             deleveragingCliff,
             lowestMaxLeverage,
+            _insurancePoolSwitchStage,
         ]
     )
 

--- a/deploy/FullDeploy.js
+++ b/deploy/FullDeploy.js
@@ -200,6 +200,8 @@ module.exports = async function (hre) {
     let feeRate = 0 // 0 percent
     let fundingRateSensitivity = 1
     let maxLiquidationSlippage = ethers.utils.parseEther("50") // 50 percent
+    let deleveragingCliff = ethers.utils.parseEther("0.2") // 20 percent
+    let lowestMaxLeverage = ethers.utils.parseEther("12.5") // Default -> Doesn't go down
 
     var deployTracerData = ethers.utils.defaultAbiCoder.encode(
         [
@@ -223,8 +225,8 @@ module.exports = async function (hre) {
             fundingRateSensitivity,
             feeRate,
             deployer,
-            ethers.utils.parseEther("0.2"), // 20 percent
-            ethers.utils.parseEther("2"),
+            deleveragingCliff,
+            lowestMaxLeverage,
         ]
     )
 

--- a/scripts/DeployAndAddTracer.js
+++ b/scripts/DeployAndAddTracer.js
@@ -35,6 +35,7 @@ async function main() {
             "address", // _feeReceiver,
             "uint256", // _deleveragingCliff
             "uint256", // _lowestMaxLeverage
+            "uint256", // _insurancePoolSwitchStage
         ],
         [
             ethers.utils.formatBytes32String("TEST1/USD"),
@@ -47,6 +48,7 @@ async function main() {
             deployer,
             ethers.utils.parseEther("0.2"), // 20 percent
             ethers.utils.parseEther("2"),
+            ethers.utils.parseEther("0.01"), // Switches mode at 1%
         ]
     )
     await factoryInstance.deployTracer(

--- a/scripts/DeployAndAddTracer.js
+++ b/scripts/DeployAndAddTracer.js
@@ -46,9 +46,9 @@ async function main() {
             fundingRateSensitivity,
             feeRate,
             deployer,
-            ethers.utils.parseEther("0.2"), // 20 percent
+            ethers.utils.parseEther("20"), // 20 percent
             ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("0.01"), // Switches mode at 1%
+            ethers.utils.parseEther("1"), // Switches mode at 1%
         ]
     )
     await factoryInstance.deployTracer(

--- a/scripts/DeployAndAddTracer.js
+++ b/scripts/DeployAndAddTracer.js
@@ -12,7 +12,7 @@ async function main() {
     let feeRate = 0 // 0 percent
     let maxLiquidationSlippage = "50000000000000000000" // 50 percent
     let fundingRateSensitivity = 1
-    let gasPriceOracle = await deployments.get("Oracle")
+    let gasPriceOracleAdapter = await deployments.get("GasPriceOracleAdapter")
     let trader = await deployments.get("Trader")
     let factory = await deployments.get("TracerPerpetualsFactory")
     let oracle = await deployments.get("Oracle")
@@ -32,17 +32,21 @@ async function main() {
             "uint256", //_maxLeverage,
             "uint256", //_fundingRateSensitivity,
             "uint256", //_feeRate
-            "address", // _feeReceiver
+            "address", // _feeReceiver,
+            "uint256", // _deleveragingCliff
+            "uint256", // _lowestMaxLeverage
         ],
         [
             ethers.utils.formatBytes32String("TEST1/USD"),
             token.address,
             tokenDecimals,
-            gasPriceOracle.address,
+            gasPriceOracleAdapter.address,
             maxLeverage,
             fundingRateSensitivity,
             feeRate,
-            deployer.address,
+            deployer,
+            ethers.utils.parseEther("0.2"), // 20 percent
+            ethers.utils.parseEther("2"),
         ]
     )
     await factoryInstance.deployTracer(

--- a/test/unit/Insurance.js
+++ b/test/unit/Insurance.js
@@ -40,6 +40,9 @@ const setup = deployments.createFixture(async () => {
             },
         }
     )
+    let deleveragingCliff = ethers.utils.parseEther("0.2") // 20 percent
+    let lowestMaxLeverage = ethers.utils.parseEther("12.5") // Default -> Doesn't go down
+    let _insurancePoolSwitchStage = ethers.utils.parseEther("0.01") // Switches mode at 1%
     const tracer = await tracerContractFactory.deploy(
         ethers.utils.formatBytes32String("TEST/USD"),
         testToken.address,
@@ -49,8 +52,9 @@ const setup = deployments.createFixture(async () => {
         1,
         1,
         zeroAddress,
-        ethers.utils.parseEther("0.2"), // 20 percent
-        ethers.utils.parseEther("2")
+        deleveragingCliff,
+        lowestMaxLeverage,
+        _insurancePoolSwitchStage
     )
 
     let mockTracer = await smockit(tracer)

--- a/test/unit/Insurance.js
+++ b/test/unit/Insurance.js
@@ -48,7 +48,9 @@ const setup = deployments.createFixture(async () => {
         1,
         1,
         1,
-        zeroAddress
+        zeroAddress,
+        ethers.utils.parseEther("0.2"), // 20 percent
+        ethers.utils.parseEther("2")
     )
 
     let mockTracer = await smockit(tracer)

--- a/test/unit/Insurance.js
+++ b/test/unit/Insurance.js
@@ -40,9 +40,9 @@ const setup = deployments.createFixture(async () => {
             },
         }
     )
-    let deleveragingCliff = ethers.utils.parseEther("0.2") // 20 percent
+    let deleveragingCliff = ethers.utils.parseEther("20") // 20 percent
     let lowestMaxLeverage = ethers.utils.parseEther("12.5") // Default -> Doesn't go down
-    let _insurancePoolSwitchStage = ethers.utils.parseEther("0.01") // Switches mode at 1%
+    let _insurancePoolSwitchStage = ethers.utils.parseEther("1") // Switches mode at 1%
     const tracer = await tracerContractFactory.deploy(
         ethers.utils.formatBytes32String("TEST/USD"),
         testToken.address,

--- a/test/unit/LibPerpetuals.js
+++ b/test/unit/LibPerpetuals.js
@@ -38,8 +38,8 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 const poolTarget = ethers.utils.parseEther("1000")
                 const defaultMaxLeverage = ethers.utils.parseEther("12.5")
                 const lowestMaxLeverage = ethers.utils.parseEther("2")
-                const deleveragingCliff = ethers.utils.parseEther("0.2")
-                const insurancePoolSwitchStage = ethers.utils.parseEther("0.01")
+                const deleveragingCliff = ethers.utils.parseEther("20")
+                const insurancePoolSwitchStage = ethers.utils.parseEther("1")
                 let result = await libPerpetuals.calculateTrueMaxLeverage(
                     collateralAmount,
                     poolTarget,

--- a/test/unit/LibPerpetuals.js
+++ b/test/unit/LibPerpetuals.js
@@ -31,6 +31,46 @@ describe("Unit tests: LibPerpetuals.sol", function () {
         accounts = await ethers.getSigners()
     })
 
+    describe("calculateTrueMaxLeverage", async () => {
+        context("With an empty pool", async () => {
+            it("Equals lowestMaxLeverage", async () => {
+                const collateralAmount = 0
+                const poolTarget = ethers.utils.parseEther("1000")
+                const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                const lowestMaxLeverage = ethers.utils.parseEther("2")
+                const deleveragingCliff = ethers.utils.parseEther("0.2")
+                let result = await libPerpetuals.calculateTrueMaxLeverage(
+                    collateralAmount,
+                    poolTarget,
+                    defaultMaxLeverage,
+                    lowestMaxLeverage,
+                    deleveragingCliff
+                )
+                expect(result).to.equal(lowestMaxLeverage)
+            })
+        })
+
+        context("With an overcollateralised pool (over target)", async () => {
+            it("", async () => {})
+        })
+
+        context("With a pool over deleveragingCliff", async () => {
+            it("", async () => {})
+        })
+
+        context("With lowestMaxLeverage > defaultMaxLeverage", async () => {
+            it("", async () => {})
+        })
+
+        context("When target == 0", async () => {
+            it("Equals lowestMaxLeverage", async () => {})
+        })
+
+        context("Pool under deleveragingCliff", async () => {
+            it("Returns as expected", async () => {})
+        })
+    })
+
     describe("canMatch", async () => {
         context("when called with different order prices", async () => {
             it("returns false", async () => {

--- a/test/unit/LibPerpetuals.js
+++ b/test/unit/LibPerpetuals.js
@@ -39,36 +39,236 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 const defaultMaxLeverage = ethers.utils.parseEther("12.5")
                 const lowestMaxLeverage = ethers.utils.parseEther("2")
                 const deleveragingCliff = ethers.utils.parseEther("0.2")
+                const insurancePoolSwitchStage = ethers.utils.parseEther("0.01")
                 let result = await libPerpetuals.calculateTrueMaxLeverage(
                     collateralAmount,
                     poolTarget,
                     defaultMaxLeverage,
                     lowestMaxLeverage,
-                    deleveragingCliff
+                    deleveragingCliff,
+                    insurancePoolSwitchStage
+                )
+                expect(result).to.equal(lowestMaxLeverage)
+            })
+        })
+
+        context("With a pool at insurancePoolSwitchStage", async () => {
+            it("Equals lowestMaxLeverage", async () => {
+                const collateralAmount = ethers.utils.parseEther("1")
+                const poolTarget = ethers.utils.parseEther("100")
+                const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                const lowestMaxLeverage = ethers.utils.parseEther("2")
+                const deleveragingCliff = ethers.utils.parseEther("20")
+                const insurancePoolSwitchStage = ethers.utils.parseEther("1")
+                let result = await libPerpetuals.calculateTrueMaxLeverage(
+                    collateralAmount,
+                    poolTarget,
+                    defaultMaxLeverage,
+                    lowestMaxLeverage,
+                    deleveragingCliff,
+                    insurancePoolSwitchStage
                 )
                 expect(result).to.equal(lowestMaxLeverage)
             })
         })
 
         context("With an overcollateralised pool (over target)", async () => {
-            it("", async () => {})
+            it("Returns default maxLeverage", async () => {
+                const collateralAmount = ethers.utils.parseEther("10000")
+                const poolTarget = ethers.utils.parseEther("1000")
+                const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                const lowestMaxLeverage = ethers.utils.parseEther("2")
+                const deleveragingCliff = ethers.utils.parseEther("20")
+                const insurancePoolSwitchStage = ethers.utils.parseEther("1")
+                let result = await libPerpetuals.calculateTrueMaxLeverage(
+                    collateralAmount,
+                    poolTarget,
+                    defaultMaxLeverage,
+                    lowestMaxLeverage,
+                    deleveragingCliff,
+                    insurancePoolSwitchStage
+                )
+                expect(result).to.equal(defaultMaxLeverage)
+            })
         })
 
-        context("With a pool over deleveragingCliff", async () => {
-            it("", async () => {})
+        context("With a pool at deleveragingCliff", async () => {
+            it("Returns default maxLeverage", async () => {
+                const collateralAmount = ethers.utils.parseEther("200")
+                const poolTarget = ethers.utils.parseEther("1000")
+                const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                const lowestMaxLeverage = ethers.utils.parseEther("2")
+                const deleveragingCliff = ethers.utils.parseEther("20")
+                const insurancePoolSwitchStage = ethers.utils.parseEther("1")
+                let result = await libPerpetuals.calculateTrueMaxLeverage(
+                    collateralAmount,
+                    poolTarget,
+                    defaultMaxLeverage,
+                    lowestMaxLeverage,
+                    deleveragingCliff,
+                    insurancePoolSwitchStage
+                )
+                expect(result).to.equal(defaultMaxLeverage)
+            })
         })
+
+        context("With a pool above deleveragingCliff", async () => {
+            it("Returns default maxLeverage", async () => {
+                const collateralAmount = ethers.utils.parseEther("300")
+                const poolTarget = ethers.utils.parseEther("1000")
+                const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                const lowestMaxLeverage = ethers.utils.parseEther("2")
+                const deleveragingCliff = ethers.utils.parseEther("20")
+                const insurancePoolSwitchStage = ethers.utils.parseEther("1")
+                let result = await libPerpetuals.calculateTrueMaxLeverage(
+                    collateralAmount,
+                    poolTarget,
+                    defaultMaxLeverage,
+                    lowestMaxLeverage,
+                    deleveragingCliff,
+                    insurancePoolSwitchStage
+                )
+                expect(result).to.equal(defaultMaxLeverage)
+            })
+        })
+        context(
+            "With deleveragingCliff == insurancePoolSwitchStage && percentFull < deleveragingCliff",
+            async () => {
+                it("Equals lowestMaxLeverage", async () => {
+                    const collateralAmount = ethers.utils.parseEther("10")
+                    const poolTarget = ethers.utils.parseEther("1000")
+                    const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                    const lowestMaxLeverage = ethers.utils.parseEther("2")
+                    const deleveragingCliff = ethers.utils.parseEther("10")
+                    const insurancePoolSwitchStage =
+                        ethers.utils.parseEther("10")
+                    let result = await libPerpetuals.calculateTrueMaxLeverage(
+                        collateralAmount,
+                        poolTarget,
+                        defaultMaxLeverage,
+                        lowestMaxLeverage,
+                        deleveragingCliff,
+                        insurancePoolSwitchStage
+                    )
+                    await expect(result).to.equal(lowestMaxLeverage)
+                })
+            }
+        )
 
         context("With lowestMaxLeverage > defaultMaxLeverage", async () => {
-            it("", async () => {})
+            it("Reverts", async () => {
+                const collateralAmount = ethers.utils.parseEther("19") // 19%
+                const poolTarget = ethers.utils.parseEther("100")
+                const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                const lowestMaxLeverage = ethers.utils.parseEther("20")
+                const deleveragingCliff = ethers.utils.parseEther("20")
+                const insurancePoolSwitchStage = ethers.utils.parseEther("1")
+                let result = libPerpetuals.calculateTrueMaxLeverage(
+                    collateralAmount,
+                    poolTarget,
+                    defaultMaxLeverage,
+                    lowestMaxLeverage,
+                    deleveragingCliff,
+                    insurancePoolSwitchStage
+                )
+                await expect(result).to.be.reverted
+            })
         })
 
         context("When target == 0", async () => {
-            it("Equals lowestMaxLeverage", async () => {})
+            it("Equals lowestMaxLeverage", async () => {
+                const collateralAmount = ethers.utils.parseEther("10")
+                const poolTarget = ethers.utils.parseEther("0")
+                const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                const lowestMaxLeverage = ethers.utils.parseEther("2")
+                const deleveragingCliff = ethers.utils.parseEther("20")
+                const insurancePoolSwitchStage = ethers.utils.parseEther("1")
+                let result = await libPerpetuals.calculateTrueMaxLeverage(
+                    collateralAmount,
+                    poolTarget,
+                    defaultMaxLeverage,
+                    lowestMaxLeverage,
+                    deleveragingCliff,
+                    insurancePoolSwitchStage
+                )
+                await expect(result).to.equal(lowestMaxLeverage)
+            })
         })
 
-        context("Pool under deleveragingCliff", async () => {
-            it("Returns as expected", async () => {})
-        })
+        context(
+            "When poolAmount below insurancePoolSwitchStage% of target",
+            async () => {
+                it("Equals lowestMaxLeverage", async () => {
+                    const collateralAmount = ethers.utils.parseEther("0.5")
+                    const poolTarget = ethers.utils.parseEther("100")
+                    const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                    const lowestMaxLeverage = ethers.utils.parseEther("2")
+                    const deleveragingCliff = ethers.utils.parseEther("20")
+                    const insurancePoolSwitchStage =
+                        ethers.utils.parseEther("1")
+                    let result = await libPerpetuals.calculateTrueMaxLeverage(
+                        collateralAmount,
+                        poolTarget,
+                        defaultMaxLeverage,
+                        lowestMaxLeverage,
+                        deleveragingCliff,
+                        insurancePoolSwitchStage
+                    )
+                    await expect(result).to.equal(lowestMaxLeverage)
+                })
+            }
+        )
+
+        context(
+            "Pool under deleveragingCliff and above switch stage",
+            async () => {
+                it("Returns as expected", async () => {
+                    const collateralAmount = ethers.utils.parseEther("19") // 19%
+                    const collateralAmountNormal = 19 // 19%
+                    const poolTarget = ethers.utils.parseEther("100")
+                    const poolTargetNormal = 100
+                    const defaultMaxLeverage = ethers.utils.parseEther("12.5")
+                    const defaultMaxLeverageNormal = 12.5
+                    const lowestMaxLeverage = ethers.utils.parseEther("2")
+                    const lowestMaxLeverageNormal = 2
+                    const deleveragingCliff = ethers.utils.parseEther("20")
+                    const deleveragingCliffNormal = 20
+                    const insurancePoolSwitchStage =
+                        ethers.utils.parseEther("1")
+                    const insurancePoolSwitchStageNormal = 1
+
+                    let result = await libPerpetuals.calculateTrueMaxLeverage(
+                        collateralAmount,
+                        poolTarget,
+                        defaultMaxLeverage,
+                        lowestMaxLeverage,
+                        deleveragingCliff,
+                        insurancePoolSwitchStage
+                    )
+                    let fraction =
+                        (defaultMaxLeverageNormal - lowestMaxLeverageNormal) /
+                        (deleveragingCliffNormal -
+                            insurancePoolSwitchStageNormal)
+                    fraction = fraction
+                    const expectedValue =
+                        fraction *
+                            ((collateralAmountNormal / poolTargetNormal) *
+                                100) +
+                        (lowestMaxLeverageNormal - fraction)
+
+                    const lowerBound = expectedValue - 0.001
+                    const upperBound = expectedValue + 0.001
+                    const upperWei = ethers.utils.parseEther(
+                        upperBound.toString()
+                    )
+                    const lowerWei = ethers.utils.parseEther(
+                        lowerBound.toString()
+                    )
+                    // ~ 11.947
+                    expect(result).to.be.within(lowerWei, upperWei)
+                })
+            }
+        )
     })
 
     describe("canMatch", async () => {


### PR DESCRIPTION
### Motivation
We want deleveraging to help secure the system during times of high volatility.

### Changes
- Added function `calculateTrueMaxLeverage` to LibPerpetuals, which calculates the maximum leverage based on how full the insurance pool is
- Added market parameters deleveragingCliff, lowestMaxLeverage, insurancePoolSwitchStage
- Modified deployment to reflect new market param changes
- Unit Tests

**Note:** Functional liquidation tests need to be made to test deleveraging works in E2E context.