### PR TITLE
update contract verification to avoid ambigious bytecode

### DIFF
--- a/deploy/LiveDeploy.js
+++ b/deploy/LiveDeploy.js
@@ -250,6 +250,7 @@ module.exports = async function (hre) {
     await hre.run("verify:verify", {
         address: libInsurance.address,
         constructorArguments: [],
+        contract: "contracts/lib/LibInsurance.sol:LibInsurance"
     })
     await hre.run("verify:verify", {
         address: libPricing.address,
@@ -278,6 +279,7 @@ module.exports = async function (hre) {
     await hre.run("verify:verify", {
         address: token.address,
         constructorArguments: [ethers.utils.parseEther("10000000")],
+        contract: "contracts/TestToken.sol:TestToken"
     })
     await hre.run("verify:verify", {
         address: factory.address,

--- a/deploy/LiveDeploy.js
+++ b/deploy/LiveDeploy.js
@@ -250,7 +250,7 @@ module.exports = async function (hre) {
     await hre.run("verify:verify", {
         address: libInsurance.address,
         constructorArguments: [],
-        contract: "contracts/lib/LibInsurance.sol:LibInsurance"
+        contract: "contracts/lib/LibInsurance.sol:LibInsurance",
     })
     await hre.run("verify:verify", {
         address: libPricing.address,
@@ -279,7 +279,7 @@ module.exports = async function (hre) {
     await hre.run("verify:verify", {
         address: token.address,
         constructorArguments: [ethers.utils.parseEther("10000000")],
-        contract: "contracts/TestToken.sol:TestToken"
+        contract: "contracts/TestToken.sol:TestToken",
     })
     await hre.run("verify:verify", {
         address: factory.address,

--- a/deploy/LiveVerify.js
+++ b/deploy/LiveVerify.js
@@ -191,7 +191,7 @@ module.exports = async function (hre) {
     await hre.run("verify:verify", {
         address: libInsurance.address,
         constructorArguments: [],
-        contract: "contracts/lib/LibInsurance.sol:LibInsurance"
+        contract: "contracts/lib/LibInsurance.sol:LibInsurance",
     })
     await hre.run("verify:verify", {
         address: libPricing.address,
@@ -220,7 +220,7 @@ module.exports = async function (hre) {
     await hre.run("verify:verify", {
         address: token.address,
         constructorArguments: [ethers.utils.parseEther("10000000")],
-        contract: "contracts/TestToken.sol:TestToken"
+        contract: "contracts/TestToken.sol:TestToken",
     })
     await hre.run("verify:verify", {
         address: factory.address,

--- a/deploy/LiveVerify.js
+++ b/deploy/LiveVerify.js
@@ -191,6 +191,7 @@ module.exports = async function (hre) {
     await hre.run("verify:verify", {
         address: libInsurance.address,
         constructorArguments: [],
+        contract: "contracts/lib/LibInsurance.sol:LibInsurance"
     })
     await hre.run("verify:verify", {
         address: libPricing.address,
@@ -219,6 +220,7 @@ module.exports = async function (hre) {
     await hre.run("verify:verify", {
         address: token.address,
         constructorArguments: [ethers.utils.parseEther("10000000")],
+        contract: "contracts/TestToken.sol:TestToken"
     })
     await hre.run("verify:verify", {
         address: factory.address,

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -35,7 +35,7 @@ module.exports = {
         },
         kovan: {
             url: "KOVAN_URL",
-            gasPrice: 5000000000, //5 gwei
+            gasPrice: 3000000000, //3 gwei
             accounts: { mnemonic: mnemonic },
         },
         local: {


### PR DESCRIPTION
# Motivation
Hardhat deploy had some trouble verifying certain contracts and needed explicit params to identify the contracts.

# Changes
- adds `contract` field to some deploys