### PR TITLE
Execution price/amount mismatch fix

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -292,10 +292,7 @@ contract TracerPerpetualSwaps is
         _updateAccountLeverage(order2.maker);
 
         // Update internal trade state
-        pricingContract.recordTrade(
-            executionPrice,
-            fillAmount
-        );
+        pricingContract.recordTrade(executionPrice, fillAmount);
 
         if (order1.side == Perpetuals.Side.Long) {
             emit MatchedOrders(

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -294,7 +294,7 @@ contract TracerPerpetualSwaps is
         // Update internal trade state
         pricingContract.recordTrade(
             executionPrice,
-            LibMath.min(order1.amount, order2.amount)
+            fillAmount
         );
 
         if (order1.side == Perpetuals.Side.Long) {

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -269,8 +269,8 @@ contract TracerPerpetualSwaps is
                 emit FailedOrders(
                     order2.maker,
                     order1.maker,
-                    order1Id,
-                    order2Id
+                    order2Id,
+                    order1Id
                 );
             }
             return false;

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -301,8 +301,8 @@ contract TracerPerpetualSwaps is
             emit MatchedOrders(
                 order1.maker,
                 order2.maker,
-                order1.amount,
-                order1.price,
+                fillAmount,
+                executionPrice,
                 order1Id,
                 order2Id
             );
@@ -310,8 +310,8 @@ contract TracerPerpetualSwaps is
             emit MatchedOrders(
                 order2.maker,
                 order1.maker,
-                order1.amount,
-                order1.price,
+                fillAmount,
+                executionPrice,
                 order2Id,
                 order1Id
             );


### PR DESCRIPTION
### Motivation

There was a bug where the price of execution of a trade was not accurate; this was caused by an erroneous `MatchedOrders` emission. This PR fixes that, along with an erroneous `FailedOrders` emission (whereby the right Long user was not being emitted), and fixes the correct amount of execution

### Changes
- Fix `MatchedOrders` and `FailedOrders` emissions in `TracerPerpetualSwaps` 
- Fix `recordPrice` to have correct amount of execution