### PR TITLE
Deployment Fixes

### DIFF
--- a/contracts/oracle/GasOracle.sol
+++ b/contracts/oracle/GasOracle.sol
@@ -37,14 +37,6 @@ contract GasOracle is IOracle, Ownable {
     }
 
     /**
-     * @dev Takes a gwei amount, in 10^18, and returns that amount in ether (in 10^18)
-     * @dev e.g. gweiToWei(1*10^18) -> (1*10^9) or 1*10^18/10^9
-     */
-    function gweiToWei(uint256 _gwei) public pure returns (uint256) {
-        return _gwei / (10**9);
-    }
-
-    /**
      * @notice converts a raw value to a WAD value.
      * @dev this allows consistency for oracles used throughout the protocol
      *      and allows oracles to have their decimals changed withou affecting

--- a/contracts/oracle/GasOracle.sol
+++ b/contracts/oracle/GasOracle.sol
@@ -29,10 +29,10 @@ contract GasOracle is IOracle, Ownable {
      * @dev Returned value is USD/Gas * 10^18 for compatibility with rest of calculations
      */
     function latestAnswer() external view override returns (uint256) {
-        uint256 gasPrice = toWad(uint256(gasOracle.latestAnswer()), gasOracle);
-        uint256 ethPrice = toWad(uint256(priceOracle.latestAnswer()), priceOracle);
+        uint256 gasPrice = uint256(gasOracle.latestAnswer());
+        uint256 ethPrice = uint256(priceOracle.latestAnswer());
 
-        uint256 result = PRBMathUD60x18.mul(gweiToWei(gasPrice), ethPrice);
+        uint256 result = PRBMathUD60x18.mul(gasPrice, ethPrice);
         return result;
     }
 

--- a/deploy/FullDeployTest.js
+++ b/deploy/FullDeployTest.js
@@ -204,8 +204,6 @@ module.exports = async function (hre) {
         log: true,
     })
 
-    console.log(`Factory Deployed: ${factory.address}`)
-
     let maxLeverage = ethers.utils.parseEther("12.5")
     let tokenDecimals = new ethers.BigNumber.from("18").toString()
     let feeRate = 0 // 0 percent
@@ -263,17 +261,10 @@ module.exports = async function (hre) {
         tracerAbi
     ).connect(signers[0])
 
-    console.log(`Tracer Deployed ${tracerInstance.address}`)
-
     let insurance = await tracerInstance.insuranceContract()
-    console.log(`Insurance Deployed ${insurance}`)
-
     let pricing = await tracerInstance.pricingContract()
-    console.log(`Pricing Deployed ${pricing}`)
-
     let liquidation = await tracerInstance.liquidationContract()
-    console.log(`Liquidation Deployed ${liquidation}`)
-
+    
     // Set Trader.sol to be whitelisted, as well as deployer (for testing purposes)
     await tracerInstance.setWhitelist(trader.address, true)
     await tracerInstance.setWhitelist(deployer, true)

--- a/deploy/FullDeployTest.js
+++ b/deploy/FullDeployTest.js
@@ -264,7 +264,7 @@ module.exports = async function (hre) {
     let insurance = await tracerInstance.insuranceContract()
     let pricing = await tracerInstance.pricingContract()
     let liquidation = await tracerInstance.liquidationContract()
-    
+
     // Set Trader.sol to be whitelisted, as well as deployer (for testing purposes)
     await tracerInstance.setWhitelist(trader.address, true)
     await tracerInstance.setWhitelist(deployer, true)

--- a/deploy/FullDeployTest.js
+++ b/deploy/FullDeployTest.js
@@ -41,24 +41,20 @@ module.exports = async function (hre) {
         log: true,
     })
 
-    console.log(`Trader Deployed ${trader.address}`)
-
     // deploy oracles
+    // asset price oracle => ASSET / USD
     const priceOracle = await deploy("PriceOracle", {
         from: deployer,
         log: true,
         contract: "Oracle",
     })
 
-    console.log(`Price Oracle Deployed ${priceOracle.address}`)
-
+    // Gas price oracle => fast gas / gwei
     const gasOracle = await deploy("GasOracle", {
         from: deployer,
         log: true,
         contract: "Oracle",
     })
-
-    console.log(`Gas Oracle Deployed ${gasOracle.address}`)
 
     const ethOracle = await deploy("EthOracle", {
         from: deployer,
@@ -66,20 +62,18 @@ module.exports = async function (hre) {
         contract: "Oracle",
     })
 
-    console.log(`ETH Oracle Deployed ${ethOracle.address}`)
-
     await execute(
         "EthOracle",
         { from: deployer, log: true },
         "setDecimals",
-        "18" // https://etherscan.io/address/0xe5bbbdb2bb953371841318e1edfbf727447cef2e#readContract
+        "8"
     )
 
     await execute(
         "EthOracle",
         { from: deployer, log: true },
         "setPrice",
-        ethers.utils.parseEther("3000") // 3000 USD / ETH
+        "300000000000" // 3000 USD / ETH
     )
 
     await execute(
@@ -96,6 +90,7 @@ module.exports = async function (hre) {
         "20000000000" // 20 Gwei
     )
 
+    // adapter converting asset oracle to WAD
     const oracleAdapter = await deploy("PriceOracleAdapter", {
         from: deployer,
         log: true,
@@ -103,16 +98,20 @@ module.exports = async function (hre) {
         contract: "OracleAdapter",
     })
 
-    console.log(`Oracle Adapter Deployed ${oracleAdapter.address}`)
+    // adapter converting ETH / USD to WAD
+    const ethOracleAdapter = await deploy("EthOracleAdapter", {
+        from: deployer,
+        log: true,
+        args: [ethOracle.address],
+        contract: "OracleAdapter",
+    })
 
     const gasPriceOracle = await deploy("GasPriceOracle", {
         from: deployer,
         log: true,
-        args: [ethOracle.address, gasOracle.address],
+        args: [ethOracleAdapter.address, gasOracle.address],
         contract: "GasOracle",
     })
-
-    console.log(`Gas Price Oracle Deployed ${gasPriceOracle.address}`)
 
     // deploy token with an initial supply of 100000
     const token = await deploy("QuoteToken", {
@@ -121,8 +120,6 @@ module.exports = async function (hre) {
         log: true,
         contract: "TestToken",
     })
-
-    console.log(`Quote Token Deployed ${token.address}`)
 
     const tokenAmount = ethers.utils.parseEther("1000")
     await execute(

--- a/deploy/LiveDeploy.js
+++ b/deploy/LiveDeploy.js
@@ -237,16 +237,9 @@ module.exports = async function (hre) {
         tracerAbi
     ).connect(signers[0])
 
-    console.log(`Tracer Deployed ${tracerInstance.address}`)
-
     let insurance = await tracerInstance.insuranceContract()
-    console.log(`Insurance Deployed ${insurance}`)
-
     let pricing = await tracerInstance.pricingContract()
-    console.log(`Pricing Deployed ${pricing}`)
-
     let liquidation = await tracerInstance.liquidationContract()
-    console.log(`Liquidation Deployed ${liquidation}`)
 
     // Set Trader.sol to be whitelisted, as well as deployer (for testing purposes)
     await tracerInstance.setWhitelist(trader.address, true)

--- a/deploy/LiveVerify.js
+++ b/deploy/LiveVerify.js
@@ -164,8 +164,6 @@ module.exports = async function (hre) {
         log: true,
     })
 
-    console.log(`Factory Deployed: ${factory.address}`)
-
     let maxLeverage = ethers.utils.parseEther("12.5")
     let tokenDecimals = new ethers.BigNumber.from("18").toString()
     let feeRate = 0 // 0 percent
@@ -180,16 +178,9 @@ module.exports = async function (hre) {
         tracerAbi
     ).connect(signers[0])
 
-    console.log(`Tracer Deployed ${tracerInstance.address}`)
-
     let insurance = await tracerInstance.insuranceContract()
-    console.log(`Insurance Deployed ${insurance}`)
-
     let pricing = await tracerInstance.pricingContract()
-    console.log(`Pricing Deployed ${pricing}`)
-
     let liquidation = await tracerInstance.liquidationContract()
-    console.log(`Liquidation Deployed ${liquidation}`)
 
     // verify
     await hre.run("verify:verify", {

--- a/test/unit/TracerPerpetualSwaps.js
+++ b/test/unit/TracerPerpetualSwaps.js
@@ -227,7 +227,6 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     "FailedOrders"
                 )
                 let balanceAfter = await tracer.balances(deployer)
-                console.log(balanceAfter)
                 // every field should match EXCEPT for last updated gas price
                 for (var i = 0; i < 3; i++) {
                     expect(balanceBefore[i].toString()).to.equal(


### PR DESCRIPTION
# Motivation
There were some slight issues with the handling of gas and the logic of oracles and oracle adapters on deployments.

# Changes
- does not convert to WAD inputs to `GasOracle`
- removes `gweiToWei` from `GasOracle`
- use 8 decimals for eth oracles as per chainlink feeds (https://docs.chain.link/docs/ethereum-addresses/)