### PR TITLE
Make vars public

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -36,8 +36,8 @@ contract Pricing is IPricing, Ownable {
     uint256 public override currentFundingIndex;
 
     // timing variables
-    uint256 internal startLastHour;
-    uint256 internal startLast24Hours;
+    uint256 public startLastHour;
+    uint256 public startLast24Hours;
     uint8 public currentHour;
 
     event HourlyPriceUpdated(uint256 price, uint256 currentHour);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tracer-protocol/contracts",
-    "version": "0.2.4",
+    "version": "0.2.7",
     "description": "Tracer Protocol",
     "main": "truffle-config.js",
     "directories": {


### PR DESCRIPTION
### Motivation
- in order to calculate when the next funding rate is I need to know when the last funding rate was updated
- since both currentHour and startLast24Hours start at index  0 you can calculate time till next update using currentHour

### Changes
- make startLastHour and startLast24Hours public