### PR TITLE
Fix revert insurance issue (underflow); remove unused function

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -169,19 +169,19 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
             return 0;
         }
 
-        uint256 ratio = PRBMathUD60x18.div(getPoolTarget() - collateralAmount, levNotionalValue);
+        uint256 poolTarget = getPoolTarget();
+
+        if (poolTarget <= collateralAmount) {
+            return 0;
+        }
+
+        uint256 ratio = PRBMathUD60x18.div(poolTarget - collateralAmount, levNotionalValue);
+
         return PRBMathUD60x18.mul(multiplyFactor, ratio);
     }
 
     function transferOwnership(address newOwner) public override(Ownable, IInsurance) onlyOwner {
         super.transferOwnership(newOwner);
-    }
-
-    /**
-     * @notice returns if the insurance pool needs funding or not
-     */
-    function poolNeedsFunding() external view override returns (bool) {
-        return getPoolTarget() > collateralAmount;
     }
 
     modifier onlyLiquidation() {

--- a/contracts/Interfaces/IInsurance.sol
+++ b/contracts/Interfaces/IInsurance.sol
@@ -19,6 +19,4 @@ interface IInsurance {
     function getPoolTarget() external view returns (uint256);
 
     function getPoolFundingRate() external view returns (uint256);
-
-    function poolNeedsFunding() external view returns (bool);
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "test": "test"
     },
     "dependencies": {
-        "@eth-optimism/smock": "^1.1.5",
+        "@eth-optimism/smock": "0.0.0-20215180366",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@nomiclabs/hardhat-etherscan": "^2.1.2",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -19,6 +19,7 @@
         "eth-sig-util": "^2.5.3",
         "ethereum-waffle": "^3.3.0",
         "ethers": "^5.1.4",
+        "hardhat": "^2.4.0",
         "hardhat-deploy": "^0.7.5",
         "prb-math": "^1.0.5",
         "prettier": "^2.3.1",
@@ -36,7 +37,6 @@
         "arb-ethers-web3-bridge": "^0.7.3",
         "chai": "^4.3.4",
         "ganache-cli": "^6.12.0",
-        "hardhat": "^2.2.1",
         "hardhat-abi-exporter": "^2.2.1",
         "hardhat-contract-sizer": "^2.0.3",
         "hardhat-deploy": "^0.7.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "test": "test"
     },
     "dependencies": {
-        "@eth-optimism/smock": "^1.1.4",
+        "@eth-optimism/smock": "^1.1.5",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@nomiclabs/hardhat-etherscan": "^2.1.2",
         "@nomiclabs/hardhat-waffle": "^2.0.1",


### PR DESCRIPTION
## Motivation

While the insurance buffer fix is underway, there was an issue whereby if the `collateralAmount` (holdings in pool) was greater than the amount needed by the insurance, there would be underflow and the transaction would revert. This fixes that by returning 0 as the insurance funding rate if the amount in the pool is greater than needed (as it should).

## Changes

- Fix insurance underflow
- Remove unused function (`poolNeedsFunding`)