### PR TITLE
claimEscrow doesn't requires msg.sender=liquidatee

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -109,7 +109,6 @@ contract Liquidation is ILiquidation, Ownable {
      */
     function claimEscrow(uint256 receiptId) public override {
         LibLiquidation.LiquidationReceipt memory receipt = liquidationReceipts[receiptId];
-        require(receipt.liquidatee == msg.sender, "LIQ: Liquidatee mismatch");
         require(!receipt.escrowClaimed, "LIQ: Escrow claimed");
         require(block.timestamp > receipt.releaseTime, "LIQ: Not released");
 

--- a/test/functional/Liquidation.js
+++ b/test/functional/Liquidation.js
@@ -1311,15 +1311,6 @@ describe("Liquidation functional tests", async () => {
             ])
             await network.provider.send("evm_mine", [])
         }
-        context("when caller is not liquidatee", async () => {
-            it("Reverts ", async () => {
-                const contracts = await setupLiquidationTest()
-                accounts = await ethers.getSigners()
-                await increaseFifteenMinutes()
-                const tx = contracts.liquidation.claimEscrow(0)
-                await expect(tx).to.be.revertedWith("LIQ: Liquidatee mismatch")
-            })
-        })
 
         context(
             "when receipt already claimed through claimEscrow",


### PR DESCRIPTION
### Motivation
We want anybody to be able to claim escrows on anybody else's behalf.

### Changes
- Removed `msg.sender == liquidatee` check on `claimEscrow(...)`