### PR TITLE
Use appropriate filled amount in matchOrders

### DIFF
--- a/contracts/Interfaces/IPricing.sol
+++ b/contracts/Interfaces/IPricing.sol
@@ -6,6 +6,8 @@ import "../lib/LibPrices.sol";
 interface IPricing {
     function getFundingRate(uint256 index) external view returns (Prices.FundingRateInstant memory);
 
+    function currentHour() external returns (uint8);
+
     function getInsuranceFundingRate(uint256 index) external view returns (Prices.FundingRateInstant memory);
 
     function currentFundingIndex() external view returns (uint256);

--- a/contracts/Interfaces/ITracerPerpetualSwaps.sol
+++ b/contracts/Interfaces/ITracerPerpetualSwaps.sol
@@ -90,5 +90,9 @@ interface ITracerPerpetualSwaps {
 
     function withdraw(uint256 amount) external;
 
-    function matchOrders(Perpetuals.Order memory order1, Perpetuals.Order memory order2) external returns (bool);
+    function matchOrders(
+        Perpetuals.Order memory order1,
+        Perpetuals.Order memory order2,
+        uint256 fillAmount
+    ) external returns (bool);
 }

--- a/contracts/Interfaces/ITrader.sol
+++ b/contracts/Interfaces/ITrader.sol
@@ -11,6 +11,10 @@ interface ITrader {
 
     function hashOrder(Perpetuals.Order memory order) external view returns (bytes32);
 
+    function filled(bytes32) external view returns (uint256);
+
+    function averageExecutionPrice(bytes32) external view returns (uint256);
+
     function getDomain() external view returns (bytes32);
 
     function verifySignature(address signer, Types.SignedLimitOrder memory order) external view returns (bool);

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -38,7 +38,7 @@ contract Pricing is IPricing, Ownable {
     // timing variables
     uint256 public startLastHour;
     uint256 public startLast24Hours;
-    uint8 public currentHour;
+    uint8 public override currentHour;
 
     event HourlyPriceUpdated(uint256 price, uint256 currentHour);
     event FundingRateUpdated(int256 fundingRate, int256 cumulativeFundingRate);

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -126,9 +126,9 @@ library Balances {
      * @notice Gets the amount that can be matched between two orders
      *         Calculated as min(amountRemaining)
      * @param orderA First order
-     * @param fillA Amount of the first order remaining to be filled
+     * @param fillA Amount of the first order that has been filled
      * @param orderB Second order
-     * @param fillB Amount of the second order remaining to be filled
+     * @param fillB Amount of the second order that has been filled
      * @return Amount matched between two orders
      */
     function fillAmount(

--- a/deploy/FullDeployTest.js
+++ b/deploy/FullDeployTest.js
@@ -39,6 +39,7 @@ module.exports = async function (hre) {
     const trader = await deploy("Trader", {
         from: deployer,
         log: true,
+        contract: "TraderMock",
     })
 
     // deploy oracles

--- a/scripts/SimulateTrading.js
+++ b/scripts/SimulateTrading.js
@@ -16,6 +16,11 @@ async function main() {
         0
     )
     let tracerInstance = new ethers.Contract(tracer, tracerAbi)
+    const traderDeployment = await deployments.get("Trader")
+    let traderInstance = await ethers.getContractAt(
+        traderDeployment.abi,
+        traderDeployment.address
+    )
 
     // approve for deployer
     console.log(`Approving tokens for the deployer: ${deployer.address}`)
@@ -96,9 +101,21 @@ async function main() {
             block.timestamp + 100, // expiry,
             0, // created
         ]
+        const mockSignedMake = [
+            makerOrder,
+            ethers.utils.formatBytes32String("DummyString"),
+            ethers.utils.formatBytes32String("DummyString"),
+            0,
+        ]
+        const mockSignedTake = [
+            takerOrder,
+            ethers.utils.formatBytes32String("DummyString"),
+            ethers.utils.formatBytes32String("DummyString"),
+            0,
+        ]
 
         console.log("Matching orders")
-        await tracerInstance.matchOrders(makerOrder, takerOrder)
+        await traderInstance.executeTrade([mockSignedMake], [mockSignedTake])
         console.log("Successfully matched orders")
         let newPrice = price
             .add(Math.random() > 0.5 ? smallAmount : smallAmount.mul(-1))

--- a/test/unit/TracerPerpetualSwaps.js
+++ b/test/unit/TracerPerpetualSwaps.js
@@ -46,6 +46,11 @@ const setup = deployments.createFixture(async () => {
     pricing.smocked.currentFundingIndex.will.return(0)
     // pricing.smocked.getFundingRate.will.return
     // pricing.smocked.getInsuranceFundingRate.will.return
+    const traderDeployment = await deployments.get("Trader")
+    let traderInstance = await ethers.getContractAt(
+        traderDeployment.abi,
+        traderDeployment.address
+    )
 
     return {
         tracer,
@@ -54,6 +59,7 @@ const setup = deployments.createFixture(async () => {
         liquidation,
         quoteToken,
         deployer,
+        traderInstance,
     }
 })
 
@@ -65,6 +71,7 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
     let quoteToken
     let deployer
     let accounts
+    let traderInstance
 
     beforeEach(async function () {
         // todo call setup
@@ -75,6 +82,7 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
         liquidation = _setup.liquidation
         quoteToken = _setup.quoteToken
         deployer = _setup.deployer
+        traderInstance = _setup.traderInstance
         accounts = await ethers.getSigners()
     })
 
@@ -209,6 +217,12 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     3621988237, //unrealistic unix timestamp
                     1621988237,
                 ]
+                const mockSignedOrder1 = [
+                    order1,
+                    ethers.utils.formatBytes32String("DummyString"),
+                    ethers.utils.formatBytes32String("DummyString"),
+                    0,
+                ]
 
                 let order2 = [
                     deployer,
@@ -219,13 +233,22 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     3621988237, //unrealistic unix timestamp
                     1621988237,
                 ]
+                const mockSignedOrder2 = [
+                    order2,
+                    ethers.utils.formatBytes32String("DummyString"),
+                    ethers.utils.formatBytes32String("DummyString"),
+                    0,
+                ]
 
                 // will return false and not update state
                 let balanceBefore = await tracer.balances(deployer)
-                await expect(tracer.matchOrders(order1, order2)).to.emit(
-                    tracer,
-                    "FailedOrders"
+                const tx = traderInstance.executeTrade(
+                    [mockSignedOrder1],
+                    [mockSignedOrder2]
                 )
+                await expect(tx).to.emit(tracer, "FailedOrders")
+                await traderInstance.clearFilled(mockSignedOrder1)
+                await traderInstance.clearFilled(mockSignedOrder2)
                 let balanceAfter = await tracer.balances(deployer)
                 // every field should match EXCEPT for last updated gas price
                 for (var i = 0; i < 3; i++) {
@@ -259,6 +282,12 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     3621988237, //unrealistic unix timestamp
                     1621988237,
                 ]
+                const mockSignedOrder1 = [
+                    order1,
+                    ethers.utils.formatBytes32String("DummyString"),
+                    ethers.utils.formatBytes32String("DummyString"),
+                    0,
+                ]
 
                 let order2 = [
                     accounts[1].address,
@@ -269,12 +298,21 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     3621988237, //unrealistic unix timestamp
                     1621988237,
                 ]
+                const mockSignedOrder2 = [
+                    order2,
+                    ethers.utils.formatBytes32String("DummyString"),
+                    ethers.utils.formatBytes32String("DummyString"),
+                    0,
+                ]
 
                 let balanceBefore = await tracer.balances(deployer)
-                await expect(tracer.matchOrders(order1, order2)).to.emit(
-                    tracer,
-                    "FailedOrders"
+                const tx = traderInstance.executeTrade(
+                    [mockSignedOrder1],
+                    [mockSignedOrder2]
                 )
+                await expect(tx).to.emit(tracer, "FailedOrders")
+                await traderInstance.clearFilled(mockSignedOrder1)
+                await traderInstance.clearFilled(mockSignedOrder2)
                 let balanceAfter = await tracer.balances(deployer)
 
                 // every field should match EXCEPT for last updated gas price
@@ -471,6 +509,12 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     expires: now + 604800, // now + 7 days
                     created: now - 1,
                 }
+                const mockSignedOrder1 = [
+                    order1,
+                    ethers.utils.formatBytes32String("DummyString"),
+                    ethers.utils.formatBytes32String("DummyString"),
+                    0,
+                ]
 
                 let order2 = {
                     maker: accounts[2].address,
@@ -481,13 +525,22 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     expires: now + 604800, // now + 7 days
                     created: now,
                 }
+                const mockSignedOrder2 = [
+                    order2,
+                    ethers.utils.formatBytes32String("DummyString"),
+                    ethers.utils.formatBytes32String("DummyString"),
+                    0,
+                ]
 
                 // check pricing is in hour 0
                 let currentHour = await pricing.currentHour()
                 expect(currentHour).to.equal(0)
 
                 // place trades
-                await tracer.connect(accounts[0]).matchOrders(order1, order2)
+                await traderInstance.executeTrade(
+                    [mockSignedOrder1],
+                    [mockSignedOrder2]
+                )
             })
 
             it("pays the funding rate", async () => {
@@ -727,6 +780,12 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     expires: now + 604800, // now + 7 days
                     created: now - 1,
                 }
+                const mockSignedOrder1 = [
+                    order1,
+                    ethers.utils.formatBytes32String("DummyString"),
+                    ethers.utils.formatBytes32String("DummyString"),
+                    0,
+                ]
 
                 let order2 = {
                     maker: accounts[2].address,
@@ -737,8 +796,17 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     expires: now + 604800, // now + 7 days
                     created: now,
                 }
+                const mockSignedOrder2 = [
+                    order2,
+                    ethers.utils.formatBytes32String("DummyString"),
+                    ethers.utils.formatBytes32String("DummyString"),
+                    0,
+                ]
 
-                await tracer.connect(accounts[0]).matchOrders(order1, order2)
+                await traderInstance.executeTrade(
+                    [mockSignedOrder1],
+                    [mockSignedOrder2]
+                )
             })
 
             it("withdraws the fees", async () => {


### PR DESCRIPTION
### Motivation
TracerPerps.matchOrder had its own `filled` mapping, which it was reading from but never actually using (it was always zero). The Trader.sol contract was keeping track of filled amounts for each order, so matchOrder should use that.

### Changes
- Made matchOrders take `fillAmount` param, as it was being passed in by Trader.sol but not actually used
- Changed `TracerPerpetualSwaps.matchOrders(...)` to use the `Trader.filled` mapping to get filled amounts
    - Since this makes a contract function call now, tests can't call `matchOrders(...)` directly, so they have to go through a new TraderMock.sol
**TraderMock.sol**
- TraderMock.sol was added, which does `Trader.executeTrade(...)` without signature checks
- TraderMock.executeTrade is used by passing in a `Types.SignedLimitOrder` with the order inside, and the signature data just as dummy variables.
- I can't just pass in `Perpetuals.Order`s, because that violates the `ITrader.sol` interface.
---------------
- Go through the tests and use `TraderMock.executeTrade(...)` instead of `TracerPerpetualSwaps.matchOrders(...)`.
- Since now the orders' filled amounts actually get updated, you have to clear the filled amount if you specifically want to reuse an order
- An alternative is to make multiple of the same orders, just with slightly differing created times or something, so their order IDs will be different