### PR TITLE
Truncate messages in require statements

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -185,7 +185,7 @@ contract Insurance is IInsurance, Ownable, SafetyWithdraw {
     }
 
     modifier onlyLiquidation() {
-        require(msg.sender == tracer.liquidationContract(), "INS: sender is not Liquidation contract");
+        require(msg.sender == tracer.liquidationContract(), "INS: sender not LIQ contract");
         _;
     }
 }

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -230,7 +230,7 @@ contract Liquidation is ILiquidation, Ownable {
 
         require(
             checkPartialLiquidation(updatedPosition, liquidatedBalance.lastUpdatedGasPrice),
-            "LIQ: Liquidation leaves too little left over"
+            "LIQ: leaves too little left over"
         );
 
         tracer.updateAccountsOnLiquidation(

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -359,7 +359,7 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
         liquidateeBalance.position.base = liquidateeBalance.position.base + liquidateeBaseChange;
 
         // Checks if the liquidator is in a valid position to process the liquidation
-        require(userMarginIsValid(liquidator), "TCR: Liquidator under minimum margin");
+        require(userMarginIsValid(liquidator), "TCR: Liquidator under min margin");
     }
 
     /**
@@ -385,7 +385,7 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
         balances[insuranceAddr].position.quote = balances[insuranceAddr].position.quote - amountToTakeFromInsurance;
         balances[claimant].position.quote = balances[claimant].position.quote + amountToGiveToClaimant;
         balances[liquidatee].position.quote = balances[liquidatee].position.quote + amountToGiveToLiquidatee;
-        require(balances[insuranceAddr].position.quote >= 0, "TCR: Insurance not adequately funded");
+        require(balances[insuranceAddr].position.quote >= 0, "TCR: Insurance not funded enough");
     }
 
     /**

--- a/test/functional/Liquidation.js
+++ b/test/functional/Liquidation.js
@@ -501,7 +501,7 @@ describe("Liquidation functional tests", async () => {
                         accounts[0].address
                     )
                     await expect(tx).to.be.revertedWith(
-                        "TCR: Liquidator under minimum margin"
+                        "TCR: Liquidator under min margin"
                     )
                 })
             }

--- a/test/unit/Insurance.js
+++ b/test/unit/Insurance.js
@@ -354,7 +354,7 @@ describe("Unit tests: Insurance.sol", function () {
             it("reverts", async () => {
                 await expect(
                     insurance.drainPool(ethers.utils.parseEther("1"))
-                ).to.be.revertedWith("INS: sender is not Liquidation contract")
+                ).to.be.revertedWith("INS: sender not LIQ contract")
             })
         })
     })

--- a/test/unit/TracerPerpetualSwaps.js
+++ b/test/unit/TracerPerpetualSwaps.js
@@ -355,7 +355,7 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                         ethers.utils.parseEther("1"),
                         ethers.utils.parseEther("1")
                     )
-                ).to.be.revertedWith("TCR: Liquidator under minimum margin")
+                ).to.be.revertedWith("TCR: Liquidator under min margin")
             })
         })
 


### PR DESCRIPTION
## Motivation

> Every reason string takes at least 32 bytes so make sure your string fits in 32 bytes or it will become more expensive

[Source](https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6)

There were a few reason strings in the contracts that had more than 32 characters. This pull request truncates them.

## Changes

- Change `require`'s in the various contracts to have a reason message that's <= 32 bytes 