### PR TITLE
Add gas reporting

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,6 +6,7 @@ require("hardhat-abi-exporter")
 require("hardhat-typechain")
 require("@nomiclabs/hardhat-etherscan")
 require("solidity-coverage")
+require("hardhat-gas-reporter")
 
 const mnemonic = ""
 
@@ -61,5 +62,9 @@ module.exports = {
         // Your API key for Etherscan
         // Obtain one at https://etherscan.io/
         apiKey: "API_KEY",
+    },
+    gasReporter: {
+      currency: "AUD",
+      coinmarketcap: "49e42c5c-1288-4e17-8c27-cd1a0aba014d",
     },
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -64,7 +64,7 @@ module.exports = {
         apiKey: "API_KEY",
     },
     gasReporter: {
-      currency: "AUD",
-      coinmarketcap: "49e42c5c-1288-4e17-8c27-cd1a0aba014d",
+        currency: "AUD",
+        coinmarketcap: "49e42c5c-1288-4e17-8c27-cd1a0aba014d",
     },
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "ethers": "^5.1.4",
         "hardhat": "^2.4.0",
         "hardhat-deploy": "^0.7.5",
+        "hardhat-gas-reporter": "^1.0.4",
         "prb-math": "^1.0.5",
         "prettier": "^2.3.1",
         "prettier-plugin-solidity": "^1.0.0-beta.13",


### PR DESCRIPTION
# Motivation
Often people make claims about gas optimisations or behaviour of the EVM without hard numbers to back them up. This fixes that.

# Changes
 - Add `hardhat-gas-reporter`
