### PR TITLE
Prefer conversion over casting

### DIFF
--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -189,8 +189,8 @@ library Balances {
      * that don't have 18 decimal places
      */
     function tokenToWad(uint256 tokenDecimals, uint256 amount) internal pure returns (int256) {
-        int256 scaler = int256(10**(MAX_DECIMALS - tokenDecimals));
-        return amount.toInt256() * scaler;
+        uint256 scaler = 10**(MAX_DECIMALS - tokenDecimals);
+        return amount.toInt256() * scaler.toInt256();
     }
 
     /**

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -86,7 +86,7 @@ library Prices {
         uint256 oldLeverage,
         uint256 newLeverage
     ) public pure returns (uint256) {
-        int256 newGlobalLeverage = int256(_globalLeverage) + (int256(newLeverage) - int256(oldLeverage));
+        int256 newGlobalLeverage = _globalLeverage.toInt256() + newLeverage.toInt256() - oldLeverage.toInt256();
 
         // note: this would require a bug in how account leverage was recorded
         // as newLeverage - oldLeverage (leverage delta) would be greater than the
@@ -192,7 +192,7 @@ library Prices {
     ) internal pure returns (Balances.Position memory, Balances.Position memory) {
         int256 insuranceDelta = PRBMathSD59x18.mul(
             globalRate.fundingRate - userRate.fundingRate,
-            int256(totalLeveragedValue)
+            totalLeveragedValue.toInt256()
         );
 
         if (insuranceDelta > 0) {


### PR DESCRIPTION
# Motivation
We should rely on our internal `toInt256` function rather than directly casting via `int256(n)`.

# Changes
 - Make `tokenToWad` use `toInt256`
 - Make `globalLeverage` use `toInt256`
 - Make `applyInsurance` use `toInt256`