### PR TITLE
FailedOrder emits amount + test fixes

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -70,7 +70,13 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
         bytes32 longOrderId,
         bytes32 shortOrderId
     );
-    event FailedOrders(address indexed long, address indexed short, bytes32 longOrderId, bytes32 shortOrderId);
+    event FailedOrders(
+        address indexed long,
+        address indexed short,
+        uint256 amount,
+        bytes32 longOrderId,
+        bytes32 shortOrderId
+    );
 
     /**
      * @notice Creates a new tracer market and sets the initial funding rate of the market. Anyone
@@ -255,11 +261,12 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
                 trueMaxLeverage()
             )
         ) {
+            // long order must have a price >= short order
             // emit failed to match event and return false
             if (order1.side == Perpetuals.Side.Long) {
-                emit FailedOrders(order1.maker, order2.maker, order1Id, order2Id);
+                emit FailedOrders(order1.maker, order2.maker, fillAmount, order1Id, order2Id);
             } else {
-                emit FailedOrders(order2.maker, order1.maker, order2Id, order1Id);
+                emit FailedOrders(order2.maker, order1.maker, fillAmount, order2Id, order1Id);
             }
             return false;
         }

--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -232,7 +232,7 @@ contract Trader is ITrader {
         bool order2Market = signedOrder2.order.market != address(0);
         bool order1Maker = signedOrder1.order.maker != address(0);
         bool order2Maker = signedOrder2.order.maker != address(0);
-        return order1Maker && order2Maker && order1Maker && order2Maker;
+        return order1Market && order2Market && order1Maker && order2Maker;
     }
 
     /**

--- a/test/functional/TracerPerpetualSwaps.js
+++ b/test/functional/TracerPerpetualSwaps.js
@@ -115,7 +115,7 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                     amount: ethers.utils.parseEther("50"),
                     side: 0, // long,
                     expires: now + 604800, // now + 7 days
-                    created: now - 1,
+                    created: now - 100,
                 }
                 const mockSignedOrder1 = [
                     order1,
@@ -131,7 +131,7 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                     amount: ethers.utils.parseEther("40"),
                     side: 1, // short,
                     expires: now + 604800, // now + 7 days
-                    created: now,
+                    created: now - 100,
                 }
                 const mockSignedOrder2 = [
                     order2,
@@ -147,7 +147,7 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                     amount: ethers.utils.parseEther("10"),
                     side: 1, // short,
                     expires: now + 604800, // now + 7 days
-                    created: now,
+                    created: now - 100,
                 }
                 const mockSignedOrder3 = [
                     order3,
@@ -163,7 +163,7 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                     amount: ethers.utils.parseEther("50"),
                     side: 0, // long,
                     expires: now + 604800, // now + 7 days
-                    created: now - 1,
+                    created: now - 100,
                 }
                 const mockSignedOrder4 = [
                     order4,
@@ -179,7 +179,7 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                     amount: ethers.utils.parseEther("10"),
                     side: 1, // short,
                     expires: now + 604800, // now + 7 days
-                    created: now,
+                    created: now - 100,
                 }
                 const mockSignedOrder5 = [
                     order5,

--- a/test/unit/TracerPerpetualSwaps.js
+++ b/test/unit/TracerPerpetualSwaps.js
@@ -679,7 +679,7 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     amount: ethers.utils.parseEther("100"),
                     side: 0, // long,
                     expires: now + 604800, // now + 7 days
-                    created: now - 1,
+                    created: now - 100,
                 }
                 const mockSignedOrder1 = [
                     order1,
@@ -695,7 +695,7 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                     amount: ethers.utils.parseEther("100"),
                     side: 1, // short,
                     expires: now + 604800, // now + 7 days
-                    created: now,
+                    created: now - 100,
                 }
                 const mockSignedOrder2 = [
                     order2,


### PR DESCRIPTION
### Motivation
It would be useful to the liquidator bot (and potentially others) for `event FailedOrders(...)` to emit the amount that failed to fill.

### Changes
- Add `amount` to FailedOrders
- Fixed tests where `order.created` was too late