### PR TITLE
Remove margin check on settle

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -486,7 +486,6 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
 
             // Update account index
             accountBalance.lastUpdatedIndex = lastEstablishedIndex;
-            require(userMarginIsValid(account), "TCR: Target under-margined");
             emit Settled(account, accountBalance.position.quote);
         }
     }

--- a/test/functional/Liquidation.js
+++ b/test/functional/Liquidation.js
@@ -337,8 +337,6 @@ describe("Liquidation functional tests", async () => {
         accounts = await ethers.getSigners()
     })
 
-    beforeEach(async function () {})
-
     context("calcAmountToReturn", async () => {
         context(
             "when units sold is greater than liquidation amount",


### PR DESCRIPTION
### Motivation
People should not be prevented from settling their debts or anyone elses for any reason.

The check to see if below margin requirement should only be done on voluntary changes to a position.

### Changes
- Make `settle(...)` not check margin is valid.