### PR TITLE
calcEscrowLiquidationAmount converts base to abs

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -143,7 +143,7 @@ contract Liquidation is ILiquidation, Ownable {
      * @param base Amount of base in the account to be liquidated (denominated in base tokens)
      * @param price Fair price of the asset (denominated in quote/base)
      * @param quote Amount of quote in the account to be liquidated (denominated in quote tokens)
-     * @param amount Amount of tokens to be liquidated
+     * @param amount Absolute amount of tokens to be liquidated
      * @param gasPrice Current gas price, denominated in gwei
      * @param account Account to be liquidated
      * @return Amount to be escrowed for the liquidation

--- a/contracts/lib/LibLiquidation.sol
+++ b/contracts/lib/LibLiquidation.sol
@@ -9,7 +9,6 @@ import "prb-math/contracts/PRBMathSD59x18.sol";
 
 library LibLiquidation {
     using LibMath for uint256;
-    using LibMath for int256;
     using PRBMathUD60x18 for uint256;
     using PRBMathSD59x18 for int256;
 
@@ -34,7 +33,7 @@ library LibLiquidation {
      * @dev Assumes params are WAD
      * @param minMargin User's minimum margin
      * @param currentMargin User's current margin
-     * @param amount Amount being liquidated
+     * @param amount Absolute amount being liquidated
      * @param totalBase User's total base
      */
     function calcEscrowLiquidationAmount(
@@ -44,7 +43,11 @@ library LibLiquidation {
         int256 totalBase
     ) internal pure returns (uint256) {
         int256 amountToEscrow = currentMargin - (minMargin.toInt256() - currentMargin);
-        int256 amountToEscrowProportional = PRBMathSD59x18.mul(amountToEscrow, PRBMathSD59x18.div(amount, totalBase));
+        int256 absoluteBase = PRBMathSD59x18.abs(totalBase);
+        int256 amountToEscrowProportional = PRBMathSD59x18.mul(
+            amountToEscrow,
+            PRBMathSD59x18.div(amount, absoluteBase)
+        );
         if (amountToEscrowProportional < 0) {
             return 0;
         }

--- a/test/unit/LibLiquidation.js
+++ b/test/unit/LibLiquidation.js
@@ -17,11 +17,33 @@ describe("Unit tests: LibLiquidation.sol", function () {
     })
 
     context("calcEscrowLiquidationAmount", async function () {
+        context("if base < 0", async function () {
+            it.only("Should escrow Correct amount", async function () {
+                const margin = ethers.utils.parseEther("100")
+                const minMargin = ethers.utils.parseEther("123")
+                const base = ethers.utils.parseEther("-100")
+                const amount = ethers.utils.parseEther("100")
+                // 100 - (123 - 100) = 77
+                const expectedEscrowAmount = ethers.utils.parseEther("77")
+
+                const escrowAmount =
+                    await libLiquidation.calcEscrowLiquidationAmount(
+                        minMargin,
+                        margin,
+                        amount,
+                        base
+                    )
+                expect(escrowAmount.toString()).to.equal(expectedEscrowAmount)
+            })
+        })
+    })
+
+    context("calcEscrowLiquidationAmount", async function () {
         context("if margin == minMargin", async function () {
             it("Should escrow full amount", async function () {
-                const margin = 123
-                const minMargin = 123
-                const amount = 100
+                const margin = ethers.utils.parseEther("123")
+                const minMargin = ethers.utils.parseEther("123")
+                const amount = ethers.utils.parseEther("100")
                 const expectedEscrowAmount = minMargin.toString()
 
                 const escrowAmount =
@@ -37,10 +59,11 @@ describe("Unit tests: LibLiquidation.sol", function () {
 
         context("as margin drops below minMargin", async function () {
             it("Should escrow less", async function () {
-                const margin = 100
-                const minMargin = 123
-                const amount = 100
-                const expectedEscrowAmount = 77 // 100 - (123 - 100) = 77
+                const margin = ethers.utils.parseEther("100")
+                const minMargin = ethers.utils.parseEther("123")
+                const amount = ethers.utils.parseEther("100")
+                // 100 - (123 - 100) = 77
+                const expectedEscrowAmount = ethers.utils.parseEther("77")
 
                 const escrowAmount =
                     await libLiquidation.calcEscrowLiquidationAmount(
@@ -56,10 +79,11 @@ describe("Unit tests: LibLiquidation.sol", function () {
         })
         context("once margin hits 0", async function () {
             it("Should escrow 0", async function () {
-                const margin = 0
-                const minMargin = 123
-                const amount = 100
-                const expectedEscrowAmount = 0 // min(0, 0 - (123 - 0)) = 0
+                const margin = ethers.utils.parseEther("0")
+                const minMargin = ethers.utils.parseEther("123")
+                const amount = ethers.utils.parseEther("100")
+                // min(0, 0 - (123 - 0)) = 0
+                const expectedEscrowAmount = ethers.utils.parseEther("0")
 
                 const escrowAmount =
                     await libLiquidation.calcEscrowLiquidationAmount(


### PR DESCRIPTION
### Motivation
`LibLiquidation.calcEscrowLiquidationAmount(...)` takes base, but if base is negative, it multiplies escrow amount by a negative, which is less than 0, thus escrowed amount will be capped at 0 even though it shouldn't be (when liquidating a short).

### Changes
- Convert `base` to `base.abs()` before doing multiplication in `calcEscrowLiquidationAmount`