### PR TITLE
Add new insurance funding rate + add tests

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -216,7 +216,13 @@ contract Insurance is IInsurance {
             return 0;
         }
 
-        uint256 ratio = PRBMathUD60x18.pow(PRBMathUD60x18.div(poolTarget - poolHoldings, poolTarget), 2 * 10**18);
+        // (poolFundingNeeded / poolTarget) is less than 10**18, which you cannot square using PRB-math;
+        // thus, we do the multiplication manually
+        uint256 poolFundingNeeded = poolTarget - poolHoldings;
+        uint256 numerator = PRBMathUD60x18.mul(poolFundingNeeded, poolFundingNeeded);
+        uint256 denominator = PRBMathUD60x18.mul(poolTarget, poolTarget);
+
+        uint256 ratio = PRBMathUD60x18.div(numerator, denominator);
 
         return PRBMathUD60x18.mul(multiplyFactor, ratio);
     }

--- a/test/unit/Insurance.js
+++ b/test/unit/Insurance.js
@@ -659,39 +659,80 @@ describe("Unit tests: Insurance.sol", function () {
             })
         })
 
-        context("when the leveraged notional value is > 0", async () => {
-            it("returns the appropriate one hour funding rate", async () => {
-                // set leveraged notional value to 100
-                mockTracer.smocked.leveragedNotionalValue.will.return.with(
-                    ethers.utils.parseEther("400")
-                )
+        context(
+            "when the leveraged notional value is > 0 and the pool is empty",
+            async () => {
+                it("returns the appropriate one hour funding rate", async () => {
+                    // set leveraged notional value to 400
+                    mockTracer.smocked.leveragedNotionalValue.will.return.with(
+                        ethers.utils.parseEther("400")
+                    )
 
-                let bufferCollateralAmount = "0"
-                let publicCollateralAmount = "0"
+                    let bufferCollateralAmount = "0"
+                    let publicCollateralAmount = "0"
 
-                await putCollateral(
-                    mockTracer,
-                    testToken,
-                    insurance,
-                    bufferCollateralAmount,
-                    publicCollateralAmount
-                )
+                    await putCollateral(
+                        mockTracer,
+                        testToken,
+                        insurance,
+                        bufferCollateralAmount,
+                        publicCollateralAmount
+                    )
 
-                let poolFundingRate = await insurance.getPoolFundingRate()
-                // poolFundingRate = constant * (ratio ** 2)
-                //                 = constant * (((fund_target - fund_holdings)/fund_target) ** 2)
-                //                 = constant * (((4 - 0)/4) ** 2)
-                //                 = constant * 1
-                let ratio = ethers.utils.parseEther("1")
-                let expectedFundingRate = FUNDING_RATE_FACTOR.mul(ratio).div(
-                    ethers.utils.parseEther("1")
-                ) // should be 0.000570775%
-                expect(expectedFundingRate).to.equal(
-                    ethers.utils.parseEther("0.00000570775")
-                )
+                    let poolFundingRate = await insurance.getPoolFundingRate()
+                    // poolFundingRate = constant * (ratio ** 2)
+                    //                 = constant * (((fund_target - fund_holdings)/fund_target) ** 2)
+                    //                 = constant * (((4 - 0)/4) ** 2)
+                    //                 = constant * 1
+                    let ratio = ethers.utils.parseEther("1")
+                    let expectedFundingRate = FUNDING_RATE_FACTOR.mul(
+                        ratio
+                    ).div(ethers.utils.parseEther("1")) // should be 0.000570775%
+                    expect(expectedFundingRate).to.equal(
+                        ethers.utils.parseEther("0.00000570775")
+                    )
 
-                expect(poolFundingRate).to.equal(expectedFundingRate)
-            })
-        })
+                    expect(poolFundingRate).to.equal(expectedFundingRate)
+                })
+            }
+        )
+
+        context(
+            "when the leveraged notional value is > 0 and the pool is not empty",
+            async () => {
+                it("returns the appropriate one hour funding rate", async () => {
+                    // set leveraged notional value to 400
+                    mockTracer.smocked.leveragedNotionalValue.will.return.with(
+                        ethers.utils.parseEther("400")
+                    )
+
+                    let bufferCollateralAmount = "1"
+                    let publicCollateralAmount = "1"
+
+                    await putCollateral(
+                        mockTracer,
+                        testToken,
+                        insurance,
+                        bufferCollateralAmount,
+                        publicCollateralAmount
+                    )
+
+                    let poolFundingRate = await insurance.getPoolFundingRate()
+                    // poolFundingRate = constant * (ratio ** 2)
+                    //                 = constant * (((fund_target - fund_holdings)/fund_target) ** 2)
+                    //                 = constant * (((4 - 2)/4) ** 2)
+                    //                 = constant * (0.5 ** 2) = constant * 0.25
+                    let ratio = ethers.utils.parseEther("0.25")
+                    let expectedFundingRate = FUNDING_RATE_FACTOR.mul(
+                        ratio
+                    ).div(ethers.utils.parseEther("1")) // should be 0.000142694063926941%
+                    expect(expectedFundingRate).to.equal(
+                        ethers.utils.parseEther("0.0000014269375") // Approximate due to imprecision
+                    )
+
+                    expect(poolFundingRate).to.equal(expectedFundingRate)
+                })
+            }
+        )
     })
 })

--- a/test/unit/Insurance.js
+++ b/test/unit/Insurance.js
@@ -4,6 +4,7 @@ const { deploy } = deployments
 const { smockit } = require("@eth-optimism/smock")
 const { BigNumber } = require("ethers")
 const zeroAddress = "0x0000000000000000000000000000000000000000"
+const FUNDING_RATE_FACTOR = ethers.utils.parseEther("0.00000570775")
 
 const getCollaterals = async (insurance) => [
     (await insurance.bufferCollateralAmount()).toString(),
@@ -629,24 +630,66 @@ describe("Unit tests: Insurance.sol", function () {
             })
         })
 
-        context("when the leveraged notional value is > 0", async () => {
-            it("returns the appropriate 8 hour funding rate", async () => {
+        context("when the pool is greater than the target", async () => {
+            it("returns 0", async () => {
                 // set leveraged notional value to 100
                 mockTracer.smocked.leveragedNotionalValue.will.return.with(
                     ethers.utils.parseEther("100")
                 )
 
+                let bufferCollateralAmount = "100"
+                let publicCollateralAmount = "100"
+
+                await putCollateral(
+                    mockTracer,
+                    testToken,
+                    insurance,
+                    bufferCollateralAmount,
+                    publicCollateralAmount
+                )
+
                 let poolFundingRate = await insurance.getPoolFundingRate()
-                // 0.0036523 * (poolTarget - total collateral) / leveragedNotionalValue))
-                // poolTarget = 100 / 1 = 1
-                // total collateral = 0
-                // leveragedNotionalValue = 100
-                // ratio = (poolTarget - collateral) / levNotionalValue = 0.01
-                let ratio = ethers.utils.parseEther("0.01")
-                let expectedFundingRate = ethers.utils
-                    .parseEther("0.0036523")
+                // poolFundingRate = constant * ratio
+                //                 = ((fund_target - fund_holdings)/fund_holdings) ** 2
+                let ratio = ethers.utils.parseEther("0")
+                let expectedFundingRate = FUNDING_RATE_FACTOR.mul(ratio)
                     .mul(ratio)
                     .div(ethers.utils.parseEther("1")) //divide by 1 to simulate WAD math division
+                expect(poolFundingRate).to.equal(expectedFundingRate)
+            })
+        })
+
+        context("when the leveraged notional value is > 0", async () => {
+            it("returns the appropriate one hour funding rate", async () => {
+                // set leveraged notional value to 100
+                mockTracer.smocked.leveragedNotionalValue.will.return.with(
+                    ethers.utils.parseEther("400")
+                )
+
+                let bufferCollateralAmount = "0"
+                let publicCollateralAmount = "0"
+
+                await putCollateral(
+                    mockTracer,
+                    testToken,
+                    insurance,
+                    bufferCollateralAmount,
+                    publicCollateralAmount
+                )
+
+                let poolFundingRate = await insurance.getPoolFundingRate()
+                // poolFundingRate = constant * (ratio ** 2)
+                //                 = constant * (((fund_target - fund_holdings)/fund_target) ** 2)
+                //                 = constant * (((4 - 0)/4) ** 2)
+                //                 = constant * 1
+                let ratio = ethers.utils.parseEther("1")
+                let expectedFundingRate = FUNDING_RATE_FACTOR.mul(ratio).div(
+                    ethers.utils.parseEther("1")
+                ) // should be 0.000570775%
+                expect(expectedFundingRate).to.equal(
+                    ethers.utils.parseEther("0.00000570775")
+                )
+
                 expect(poolFundingRate).to.equal(expectedFundingRate)
             })
         })


### PR DESCRIPTION
# Motivation

Since the original whitepaper for Tracer's perpetual swaps was released, the way that the insurance funding rate is calculated has been changed. Below is the new formula:
![image](https://user-images.githubusercontent.com/47245900/124418192-4826b680-dd9e-11eb-9e37-755377fddd42.png)

Sorry for my chopped-up three second LaTeX :((

# Changes

- Update the way that the insurance funding rate is calculated and update corresponding unit tests

