### PR TITLE
Factor trade volume into hourly price instants

### DIFF
--- a/contracts/Interfaces/IPricing.sol
+++ b/contracts/Interfaces/IPricing.sol
@@ -24,5 +24,5 @@ interface IPricing {
 
     function getHourlyAvgOraclePrice(uint256 hour) external view returns (uint256);
 
-    function recordTrade(uint256 tradePrice) external;
+    function recordTrade(uint256 tradePrice, uint256 fillAmount) external;
 }

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -8,6 +8,7 @@ import "./Interfaces/ITracerPerpetualSwaps.sol";
 import "./Interfaces/IInsurance.sol";
 import "./Interfaces/IOracle.sol";
 import "prb-math/contracts/PRBMathSD59x18.sol";
+import "prb-math/contracts/PRBMathUD60x18.sol";
 
 contract Pricing is IPricing {
     using LibMath for uint256;
@@ -122,24 +123,28 @@ contract Pricing is IPricing {
         // Price records entries updated every hour
         if (newRecord) {
             // Make new hourly record, total = marketprice, numTrades set to the amount filled;
-            Prices.PriceInstant memory newHourly = Prices.PriceInstant(marketPrice * fillAmount, fillAmount);
+            Prices.PriceInstant memory newHourly = Prices.PriceInstant(
+                PRBMathUD60x18.mul(marketPrice, fillAmount),
+                fillAmount
+            );
             hourlyTracerPrices[currentHour] = newHourly;
             // As above but with Oracle price
-            Prices.PriceInstant memory oracleHour = Prices.PriceInstant(oraclePrice * fillAmount, fillAmount);
+            Prices.PriceInstant memory oracleHour = Prices.PriceInstant(
+                PRBMathUD60x18.mul(oraclePrice, fillAmount),
+                fillAmount
+            );
             hourlyOraclePrices[currentHour] = oracleHour;
         } else {
             // If an update is needed, add the total market price of the trade to a running total
             // and increment number of fill amounts
             hourlyTracerPrices[currentHour].cumulativePrice =
                 hourlyTracerPrices[currentHour].cumulativePrice +
-                marketPrice *
-                fillAmount;
+                PRBMathUD60x18.mul(marketPrice, fillAmount);
             hourlyTracerPrices[currentHour].trades = hourlyTracerPrices[currentHour].trades + fillAmount;
             // As above but with oracle price
             hourlyOraclePrices[currentHour].cumulativePrice =
                 hourlyOraclePrices[currentHour].cumulativePrice +
-                oraclePrice *
-                fillAmount;
+                PRBMathUD60x18.mul(oraclePrice, fillAmount);
             hourlyOraclePrices[currentHour].trades = hourlyOraclePrices[currentHour].trades + fillAmount;
         }
     }

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -287,7 +287,7 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
         _updateAccountLeverage(order2.maker);
 
         // Update internal trade state
-        pricingContract.recordTrade(executionPrice);
+        pricingContract.recordTrade(executionPrice, fillAmount);
 
         if (order1.side == Perpetuals.Side.Long) {
             emit MatchedOrders(order1.maker, order2.maker, fillAmount, executionPrice, order1Id, order2Id);

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -229,8 +229,6 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
     ) external override onlyWhitelisted returns (bool) {
         bytes32 order1Id = Perpetuals.orderId(order1);
         bytes32 order2Id = Perpetuals.orderId(order2);
-        uint256 filled1 = ITrader(msg.sender).filled(order1Id);
-        uint256 filled2 = ITrader(msg.sender).filled(order2Id);
 
         uint256 executionPrice = Perpetuals.getExecutionPrice(order1, order2);
 
@@ -245,20 +243,27 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
             fillAmount,
             executionPrice
         );
+        uint256 _fairPrice = pricingContract.fairPrice();
+        uint256 _trueMaxLeverage = trueMaxLeverage();
         // validate orders can match, and outcome state is valid
         if (
-            !Perpetuals.canMatch(order1, filled1, order2, filled2) ||
+            !Perpetuals.canMatch(
+                order1,
+                ITrader(msg.sender).filled(order1Id),
+                order2,
+                ITrader(msg.sender).filled(order2Id)
+            ) ||
             !Balances.marginIsValid(
                 newPos1,
                 balances[order1.maker].lastUpdatedGasPrice * LIQUIDATION_GAS_COST,
-                pricingContract.fairPrice(),
-                trueMaxLeverage()
+                _fairPrice,
+                _trueMaxLeverage
             ) ||
             !Balances.marginIsValid(
                 newPos2,
                 balances[order2.maker].lastUpdatedGasPrice * LIQUIDATION_GAS_COST,
-                pricingContract.fairPrice(),
-                trueMaxLeverage()
+                _fairPrice,
+                _trueMaxLeverage
             )
         ) {
             // long order must have a price >= short order

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -45,7 +45,8 @@ library Prices {
         if (price.trades == 0) {
             return 0;
         }
-        return price.cumulativePrice / price.trades;
+
+        return PRBMathUD60x18.div(price.cumulativePrice, price.trades);
     }
 
     /**

--- a/scripts/DepositQuoteTokensKovan.js
+++ b/scripts/DepositQuoteTokensKovan.js
@@ -35,10 +35,9 @@ async function main() {
         tracerInstance = await tracerInstance.connect(wallet)
         if (
             (
-                await tokenInstance.connect(wallet).allowance(
-                    wallet.address,
-                    tracerInstance.address
-                )
+                await tokenInstance
+                    .connect(wallet)
+                    .allowance(wallet.address, tracerInstance.address)
             ).lt(DEPOSIT_AMOUNT)
         ) {
             const tx = await tokenInstance

--- a/test/unit/LibPrices.js
+++ b/test/unit/LibPrices.js
@@ -7,6 +7,7 @@ const calcExpectedTwaps = (oraclePrices, tracerPrices, hour) => {
     let cumulativeDerivative = ethers.BigNumber.from("0")
     let cumulativeUnderlying = ethers.BigNumber.from("0")
     let totalTimeWeight = ethers.BigNumber.from("0")
+
     for (i = 0; i < 8; i++) {
         let currTimeWeight = 8 - i
         let j = hour < i ? 24 - i + hour : hour - i
@@ -15,12 +16,19 @@ const calcExpectedTwaps = (oraclePrices, tracerPrices, hour) => {
             ethers.BigNumber.from(currTimeWeight)
         )
         cumulativeDerivative = cumulativeDerivative.add(
-            tracerPrices[j][0].div(tracerPrices[j][1]).mul(currTimeWeight)
+            tracerPrices[j][0]
+                .mul(ethers.utils.parseEther("1"))
+                .div(tracerPrices[j][1])
+                .mul(currTimeWeight)
         )
         cumulativeUnderlying = cumulativeUnderlying.add(
-            oraclePrices[j][0].div(oraclePrices[j][1]).mul(currTimeWeight)
+            oraclePrices[j][0]
+                .mul(ethers.utils.parseEther("1"))
+                .div(oraclePrices[j][1])
+                .mul(currTimeWeight)
         )
     }
+
     return [
         cumulativeUnderlying.div(totalTimeWeight),
         cumulativeDerivative.div(totalTimeWeight),
@@ -196,7 +204,7 @@ describe("Unit tests: LibPrices.sol", function () {
                 let result = await libPrices.averagePrice(price)
 
                 expect(result.toString()).to.equal(
-                    ethers.BigNumber.from("10").toString()
+                    ethers.utils.parseEther("10").toString()
                 )
             })
         })
@@ -229,16 +237,17 @@ describe("Unit tests: LibPrices.sol", function () {
                 for (i = 0; i < n; i++) {
                     prices.push([
                         ethers.utils.parseEther((i + 1).toString()),
-                        ethers.BigNumber.from(i + 1),
+                        ethers.utils.parseEther((i + 1).toString()),
                     ])
                     let dayAverage = ethers.utils
                         .parseEther((i + 1).toString())
-                        .div(ethers.BigNumber.from(i + 1))
+                        .mul(ethers.utils.parseEther("1"))
+                        .div(ethers.utils.parseEther((i + 1).toString()))
                     priceAverages = priceAverages.add(dayAverage.toString())
                 }
 
                 let averagePriceForPeriod = priceAverages.div(
-                    ethers.BigNumber.from(n)
+                    ethers.BigNumber.from(n.toString())
                 )
                 let result = await libPrices.averagePriceForPeriod(prices)
 
@@ -317,12 +326,12 @@ describe("Unit tests: LibPrices.sol", function () {
                 // generate 24 hour oracle and tracer prices
                 for (i = 0; i < 24; i++) {
                     oraclePrices.push([
-                        ethers.utils.parseUnits((1 + 1 * i).toString(), 18),
-                        ethers.BigNumber.from("1"),
+                        ethers.utils.parseEther((1 + 1 * i).toString()),
+                        ethers.utils.parseEther("1"),
                     ])
                     tracerPrices.push([
-                        ethers.utils.parseUnits((1 + 0.5 * i).toString(), 18),
-                        ethers.BigNumber.from("1"),
+                        ethers.utils.parseEther((1 + 0.5 * i).toString()),
+                        ethers.utils.parseEther("1"),
                     ])
                 }
 


### PR DESCRIPTION
# Motivation

Currently, when calculating the average price in a given hour of a market, the cumulative price is set to be the sum of the prices of all the trades, ignoring the weight of the actual trades (i.e. the number of positions sold in that trade). This leads to asymmetric averages. 

e.g. Currently, for the following two trades that happen in an hour:
- 90 pos. @ $1.25
- 10 pos. @ $1.50

The average price for that hour is calculated to be (1.25 + 1.5) / 2 = $1.375, even though based on the actual positions that were filled, it should be (90x1.25 + 10x1.5) / 100 = $1.275

This PR solves this: https://github.com/code-423n4/2021-06-tracer-findings/issues/119

# Changes
- Factor trade volume into hourly price instants
- Misc. gas optimisation in `TracerPerpetualSwaps`