### PR TITLE
Liquidation update leveraged value

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -395,6 +395,8 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
         // update liquidatee balance
         liquidateeBalance.position.quote = liquidateeBalance.position.quote + liquidateeQuoteChange;
         liquidateeBalance.position.base = liquidateeBalance.position.base + liquidateeBaseChange;
+        _updateAccountLeverage(liquidator);
+        _updateAccountLeverage(liquidatee);
 
         // Checks if the liquidator is in a valid position to process the liquidation
         require(userMarginIsValid(liquidator), "TCR: Liquidator under min margin");
@@ -423,6 +425,8 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable, SafetyWithdraw 
         balances[insuranceAddr].position.quote = balances[insuranceAddr].position.quote - amountToTakeFromInsurance;
         balances[claimant].position.quote = balances[claimant].position.quote + amountToGiveToClaimant;
         balances[liquidatee].position.quote = balances[liquidatee].position.quote + amountToGiveToLiquidatee;
+        _updateAccountLeverage(claimant);
+        _updateAccountLeverage(liquidatee);
         require(balances[insuranceAddr].position.quote >= 0, "TCR: Insurance not funded enough");
     }
 

--- a/test/functional/Liquidation.js
+++ b/test/functional/Liquidation.js
@@ -639,13 +639,13 @@ describe("Liquidation functional tests", async () => {
                 const contracts = await setupLiquidationTest()
                 accounts = await ethers.getSigners()
 
-                const liquidationAmount = (
-                    await contracts.tracer.balances(accounts[0].address)
-                ).position.base
+                const liquidateeBalance = await contracts.tracer.balances(accounts[0].address)
+                const liquidationAmount = liquidateeBalance.position.base
 
                 const baseBefore = (
                     await contracts.tracer.balances(accounts[2].address)
                 ).position.base
+
 
                 // Normal liquidation
                 const tx = await contracts.liquidation.liquidate(
@@ -662,11 +662,16 @@ describe("Liquidation functional tests", async () => {
                 ).escrowedAmount
                 expect(escrowedAmount).to.equal(expectedEscrowedAmount)
 
-                const baseAfter = (
-                    await contracts.tracer.balances(accounts[2].address)
-                ).position.base
+                const liquidateeBalanceAfter = await contracts.tracer.balances(accounts[0].address)
+                const leveragedValueAfter = liquidateeBalanceAfter.totalLeveragedValue
 
+                const balanceAfter = await contracts.tracer.balances(accounts[2].address)
+                const baseAfter = balanceAfter.position.base
+
+                expect(liquidateeBalanceAfter.position.quote).to.equal("0")
+                expect(liquidateeBalanceAfter.position.base).to.equal("0")
                 expect(baseAfter).to.equal(baseBefore.add(liquidationAmount))
+                expect(leveragedValueAfter).to.equal(BigNumber.from("0"))
             })
         })
 
@@ -674,10 +679,9 @@ describe("Liquidation functional tests", async () => {
             it("Updates accounts and escrow correctly", async () => {
                 const contracts = await setupLiquidationTest()
                 accounts = await ethers.getSigners()
-
-                const liquidationAmount = (
-                    await contracts.tracer.balances(accounts[0].address)
-                ).position.base.div(2)
+                const liquidateeBalance = await contracts.tracer.balances(accounts[0].address)
+                const liquidationAmount = liquidateeBalance.position.base.div(2)
+                const leveragedValueBefore = liquidateeBalance.totalLeveragedValue
 
                 const baseBefore = (
                     await contracts.tracer.balances(accounts[2].address)
@@ -699,10 +703,15 @@ describe("Liquidation functional tests", async () => {
                 ).escrowedAmount
                 expect(escrowedAmount).to.equal(expectedEscrowedAmount)
 
+                const liquidateeBalanceAfter = await contracts.tracer.balances(accounts[0].address)
+                const leveragedValueAfter = liquidateeBalanceAfter.totalLeveragedValue
+
                 const baseAfter = (
                     await contracts.tracer.balances(accounts[2].address)
                 ).position.base
 
+                // Leveraged value should half
+                expect(leveragedValueAfter).to.equal(leveragedValueBefore.div(2))
                 expect(baseAfter).to.equal(baseBefore.add(liquidationAmount))
             })
         })
@@ -840,9 +849,9 @@ describe("Liquidation functional tests", async () => {
                     .div(BigNumber.from("100"))
                 const slippageAmount = receiptValue.sub(sellValue)
 
-                const liquidatorQuoteBefore = (
-                    await contracts.tracerPerps.balances(accounts[1].address)
-                ).position.quote
+                const liquidatorBefore = await contracts.tracerPerps.balances(accounts[1].address)
+                const liquidatorQuoteBefore = liquidatorBefore.position.quote
+
                 const liquidateeQuoteBefore = (
                     await contracts.tracerPerps.balances(accounts[0].address)
                 ).position.quote
@@ -860,9 +869,8 @@ describe("Liquidation functional tests", async () => {
                         contracts.modifiableTrader.address
                     )
 
-                const liquidatorQuoteAfter = (
-                    await contracts.tracerPerps.balances(accounts[1].address)
-                ).position.quote
+                const liquidatorAfter = await contracts.tracerPerps.balances(accounts[1].address)
+                const liquidatorQuoteAfter = liquidatorAfter.position.quote
                 const liquidateeQuoteAfter = (
                     await contracts.tracerPerps.balances(accounts[0].address)
                 ).position.quote
@@ -870,6 +878,9 @@ describe("Liquidation functional tests", async () => {
                 expect(liquidatorQuoteAfter).to.equal(
                     liquidatorQuoteBefore.add(slippageAmount)
                 )
+
+                // Total leveraged value should go down by slippageAmount
+                expect(liquidatorAfter.totalLeveragedValue).to.equal(liquidatorBefore.totalLeveragedValue.sub(slippageAmount))
 
                 const expectedLiquidateeDifference =
                     escrowedAmount.sub(slippageAmount)
@@ -1381,9 +1392,6 @@ describe("Liquidation functional tests", async () => {
                 it("Reverts", async () => {
                     const contracts = await setupReceiptTest()
                     accounts = await ethers.getSigners()
-                    const escrowedAmount = (
-                        await contracts.liquidation.liquidationReceipts(0)
-                    ).escrowedAmount
 
                     // This order sells all liquidationAmount at $0.5, even though the receipt is $0.95,
                     // so slippage is liquidationAmount*0.95 - liquidationAmount*0.5
@@ -1402,7 +1410,6 @@ describe("Liquidation functional tests", async () => {
                             [order],
                             contracts.modifiableTrader.address
                         )
-
                     await increaseFifteenMinutes()
                     const tx = contracts.liquidation
                         .connect(accounts[0])
@@ -1427,6 +1434,11 @@ describe("Liquidation functional tests", async () => {
                             accounts[0].address
                         )
                     ).position.quote
+                    const liquidatorBefore = 
+                        await contracts.tracerPerps.balances(
+                            accounts[2].address
+                        )
+                
 
                     await increaseFifteenMinutes()
                     await contracts.liquidation
@@ -1438,7 +1450,13 @@ describe("Liquidation functional tests", async () => {
                             accounts[0].address
                         )
                     ).position.quote
+                    const liquidatorAfter = 
+                        await contracts.tracerPerps.balances(
+                            accounts[2].address
+                        )
 
+                    expect(liquidatorAfter.position.quote).to.equal(liquidatorBefore.position.quote)
+                    expect(liquidatorAfter.position.base).to.equal(liquidatorBefore.position.base)
                     expect(quoteAfter).to.equal(quoteBefore.add(escrowedAmount))
                 })
             }

--- a/test/functional/Liquidation.js
+++ b/test/functional/Liquidation.js
@@ -639,13 +639,14 @@ describe("Liquidation functional tests", async () => {
                 const contracts = await setupLiquidationTest()
                 accounts = await ethers.getSigners()
 
-                const liquidateeBalance = await contracts.tracer.balances(accounts[0].address)
+                const liquidateeBalance = await contracts.tracer.balances(
+                    accounts[0].address
+                )
                 const liquidationAmount = liquidateeBalance.position.base
 
                 const baseBefore = (
                     await contracts.tracer.balances(accounts[2].address)
                 ).position.base
-
 
                 // Normal liquidation
                 const tx = await contracts.liquidation.liquidate(
@@ -662,10 +663,15 @@ describe("Liquidation functional tests", async () => {
                 ).escrowedAmount
                 expect(escrowedAmount).to.equal(expectedEscrowedAmount)
 
-                const liquidateeBalanceAfter = await contracts.tracer.balances(accounts[0].address)
-                const leveragedValueAfter = liquidateeBalanceAfter.totalLeveragedValue
+                const liquidateeBalanceAfter = await contracts.tracer.balances(
+                    accounts[0].address
+                )
+                const leveragedValueAfter =
+                    liquidateeBalanceAfter.totalLeveragedValue
 
-                const balanceAfter = await contracts.tracer.balances(accounts[2].address)
+                const balanceAfter = await contracts.tracer.balances(
+                    accounts[2].address
+                )
                 const baseAfter = balanceAfter.position.base
 
                 expect(liquidateeBalanceAfter.position.quote).to.equal("0")
@@ -679,9 +685,12 @@ describe("Liquidation functional tests", async () => {
             it("Updates accounts and escrow correctly", async () => {
                 const contracts = await setupLiquidationTest()
                 accounts = await ethers.getSigners()
-                const liquidateeBalance = await contracts.tracer.balances(accounts[0].address)
+                const liquidateeBalance = await contracts.tracer.balances(
+                    accounts[0].address
+                )
                 const liquidationAmount = liquidateeBalance.position.base.div(2)
-                const leveragedValueBefore = liquidateeBalance.totalLeveragedValue
+                const leveragedValueBefore =
+                    liquidateeBalance.totalLeveragedValue
 
                 const baseBefore = (
                     await contracts.tracer.balances(accounts[2].address)
@@ -703,15 +712,20 @@ describe("Liquidation functional tests", async () => {
                 ).escrowedAmount
                 expect(escrowedAmount).to.equal(expectedEscrowedAmount)
 
-                const liquidateeBalanceAfter = await contracts.tracer.balances(accounts[0].address)
-                const leveragedValueAfter = liquidateeBalanceAfter.totalLeveragedValue
+                const liquidateeBalanceAfter = await contracts.tracer.balances(
+                    accounts[0].address
+                )
+                const leveragedValueAfter =
+                    liquidateeBalanceAfter.totalLeveragedValue
 
                 const baseAfter = (
                     await contracts.tracer.balances(accounts[2].address)
                 ).position.base
 
                 // Leveraged value should half
-                expect(leveragedValueAfter).to.equal(leveragedValueBefore.div(2))
+                expect(leveragedValueAfter).to.equal(
+                    leveragedValueBefore.div(2)
+                )
                 expect(baseAfter).to.equal(baseBefore.add(liquidationAmount))
             })
         })
@@ -849,7 +863,9 @@ describe("Liquidation functional tests", async () => {
                     .div(BigNumber.from("100"))
                 const slippageAmount = receiptValue.sub(sellValue)
 
-                const liquidatorBefore = await contracts.tracerPerps.balances(accounts[1].address)
+                const liquidatorBefore = await contracts.tracerPerps.balances(
+                    accounts[1].address
+                )
                 const liquidatorQuoteBefore = liquidatorBefore.position.quote
 
                 const liquidateeQuoteBefore = (
@@ -869,7 +885,9 @@ describe("Liquidation functional tests", async () => {
                         contracts.modifiableTrader.address
                     )
 
-                const liquidatorAfter = await contracts.tracerPerps.balances(accounts[1].address)
+                const liquidatorAfter = await contracts.tracerPerps.balances(
+                    accounts[1].address
+                )
                 const liquidatorQuoteAfter = liquidatorAfter.position.quote
                 const liquidateeQuoteAfter = (
                     await contracts.tracerPerps.balances(accounts[0].address)
@@ -880,7 +898,9 @@ describe("Liquidation functional tests", async () => {
                 )
 
                 // Total leveraged value should go down by slippageAmount
-                expect(liquidatorAfter.totalLeveragedValue).to.equal(liquidatorBefore.totalLeveragedValue.sub(slippageAmount))
+                expect(liquidatorAfter.totalLeveragedValue).to.equal(
+                    liquidatorBefore.totalLeveragedValue.sub(slippageAmount)
+                )
 
                 const expectedLiquidateeDifference =
                     escrowedAmount.sub(slippageAmount)
@@ -1434,11 +1454,10 @@ describe("Liquidation functional tests", async () => {
                             accounts[0].address
                         )
                     ).position.quote
-                    const liquidatorBefore = 
+                    const liquidatorBefore =
                         await contracts.tracerPerps.balances(
                             accounts[2].address
                         )
-                
 
                     await increaseFifteenMinutes()
                     await contracts.liquidation
@@ -1450,13 +1469,17 @@ describe("Liquidation functional tests", async () => {
                             accounts[0].address
                         )
                     ).position.quote
-                    const liquidatorAfter = 
+                    const liquidatorAfter =
                         await contracts.tracerPerps.balances(
                             accounts[2].address
                         )
 
-                    expect(liquidatorAfter.position.quote).to.equal(liquidatorBefore.position.quote)
-                    expect(liquidatorAfter.position.base).to.equal(liquidatorBefore.position.base)
+                    expect(liquidatorAfter.position.quote).to.equal(
+                        liquidatorBefore.position.quote
+                    )
+                    expect(liquidatorAfter.position.base).to.equal(
+                        liquidatorBefore.position.base
+                    )
                     expect(quoteAfter).to.equal(quoteBefore.add(escrowedAmount))
                 })
             }


### PR DESCRIPTION
# Motivation
Account leverage was not updated on liquidation. Obviously, when somebody gets liquidated, their total leveraged value should decrease appropriately (and vise-verse for the liquidator).

# Changes
- Added calls to `TracerPerpetualSwaps._updateAccountLeverage(...)` in `updateAccountsOnLiquidation(...)` and `updateAccountsOnClaim(...)`
- 