### PR TITLE
Add explicit token decimal check

### DIFF
--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -218,6 +218,7 @@ library Balances {
      * that don't have 18 decimal places
      */
     function tokenToWad(uint256 tokenDecimals, uint256 amount) internal pure returns (int256) {
+        require(tokenDecimals <= 18, "max decimals exceeded");
         uint256 scaler = 10**(MAX_DECIMALS - tokenDecimals);
         return amount.toInt256() * scaler.toInt256();
     }
@@ -226,6 +227,7 @@ library Balances {
      * @notice converts a wad token amount to its raw representation.
      */
     function wadToToken(uint256 tokenDecimals, uint256 wadAmount) internal pure returns (uint256) {
+        require(tokenDecimals <= 18, "max decimals exceeded");
         uint256 scaler = uint256(10**(MAX_DECIMALS - tokenDecimals));
         return uint256(wadAmount / scaler);
     }


### PR DESCRIPTION
# Motivation
The contracts assume that tokens used have 18 decimals or less. An explicit check should be added in the case a token with more than 18 digits is used.

# Changes
Added an explicit require check for affected functions