### PR TITLE
Fix fee subtraction logic issue

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ types/*
 cache/*
 *.md
 *.tmp
+coverage/*

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -38,7 +38,7 @@ library Balances {
 
     /**
      * @notice Calculates the notional value of a position as base * price
-     * @param position the position the account is currently in
+     * @param position The position the account is currently in
      * @param price The (fair) price of the base asset
      * @return Notional value of a position given the price
      */
@@ -106,15 +106,14 @@ library Balances {
         uint256 liquidationGasCost,
         uint256 maximumLeverage
     ) internal pure returns (uint256) {
-        // There should be no Minimum margin when user has no position
+        // There should be no minimum margin when user has no position
         if (position.base == 0) {
             return 0;
         }
 
-        uint256 _notionalValue = notionalValue(position, price);
-
         uint256 adjustedLiquidationGasCost = liquidationGasCost * 6;
 
+        uint256 _notionalValue = notionalValue(position, price);
         uint256 minimumMarginWithoutGasCost = PRBMathUD60x18.div(_notionalValue, maximumLeverage);
 
         return adjustedLiquidationGasCost + minimumMarginWithoutGasCost;
@@ -124,7 +123,7 @@ library Balances {
      * @notice Checks the validity of a potential margin given the necessary parameters
      * @param position The position
      * @param liquidationGasCost The cost of calling liquidate
-     * @return a bool representing the validity of a margin
+     * @return Whether the margin of a given position is valid
      */
     function marginIsValid(
         Balances.Position memory position,
@@ -183,16 +182,16 @@ library Balances {
         int256 newBase = 0;
 
         if (trade.side == Perpetuals.Side.Long) {
+            // Long positions have their positions increased
             newBase = position.base + signedAmount;
             newQuote = position.quote - quoteChange + fee;
         } else if (trade.side == Perpetuals.Side.Short) {
+            // Short positions have their positions decreased
             newBase = position.base - signedAmount;
             newQuote = position.quote + quoteChange - fee;
         }
 
-        Position memory newPosition = Position(newQuote, newBase);
-
-        return newPosition;
+        return Position({quote: newQuote, base: newBase});
     }
 
     /**
@@ -209,12 +208,12 @@ library Balances {
     ) internal pure returns (int256) {
         uint256 quoteChange = PRBMathUD60x18.mul(amount, executionPrice);
 
-        int256 fee = PRBMathUD60x18.mul(quoteChange, feeRate).toInt256();
-        return fee;
+        // fee = quoteChange * feeRate
+        return PRBMathUD60x18.mul(quoteChange, feeRate).toInt256();
     }
 
     /**
-     * @notice converts a raw token amount to its WAD representation. Used for tokens
+     * @notice Converts a raw token amount to its WAD representation. Used for tokens
      * that don't have 18 decimal places
      */
     function tokenToWad(uint256 tokenDecimals, uint256 amount) internal pure returns (int256) {
@@ -223,7 +222,7 @@ library Balances {
     }
 
     /**
-     * @notice converts a wad token amount to its raw representation.
+     * @notice Converts a wad token amount to its raw representation.
      */
     function wadToToken(uint256 tokenDecimals, uint256 wadAmount) internal pure returns (uint256) {
         uint256 scaler = uint256(10**(MAX_DECIMALS - tokenDecimals));

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -182,11 +182,11 @@ library Balances {
         int256 newBase = 0;
 
         if (trade.side == Perpetuals.Side.Long) {
-            // Long positions have their positions increased
+            // Long trades have their base increased & quote decreased
             newBase = position.base + signedAmount;
-            newQuote = position.quote - quoteChange + fee;
+            newQuote = position.quote - quoteChange - fee;
         } else if (trade.side == Perpetuals.Side.Short) {
-            // Short positions have their positions decreased
+            // Short trades have their base decreased & quote increased
             newBase = position.base - signedAmount;
             newQuote = position.quote + quoteChange - fee;
         }

--- a/test/unit/LibBalances.js
+++ b/test/unit/LibBalances.js
@@ -28,7 +28,7 @@ const getTradePosition = (position, trade, feeRate) => {
     if (trade[2] === 0) {
         // long
         return [
-            position[0].sub(quoteChange).add(fee),
+            position[0].sub(quoteChange).sub(fee),
             position[1].add(trade[1]),
         ]
     } else {
@@ -593,14 +593,18 @@ describe("Unit tests: LibBalances.sol", async () => {
                     ethers.utils.parseEther("10"),
                     ethers.utils.parseEther("0"),
                 ]
-                // long 5 units at $2
+                // long 5 units at $1
                 let trade = [
-                    ethers.utils.parseEther("2"),
+                    ethers.utils.parseEther("1"),
                     ethers.utils.parseEther("5"),
                     0,
                 ]
-                let feeRate = ethers.BigNumber.from("0")
+                let feeRate = ethers.utils.parseEther("0.1")
                 let expected = getTradePosition(position, trade, feeRate)
+                // 5 units at $1, with a feeRate of 10% => $0.5 fee
+                // Starting base was $10; after the trade, goes down by $5 (5 units * $1 / unit)
+                // 10 - 5 - 0.5 = 4.5
+                expect(expected[0]).to.equal(ethers.utils.parseEther("4.5"))
                 let result = await libBalances.applyTrade(
                     position,
                     trade,
@@ -622,8 +626,12 @@ describe("Unit tests: LibBalances.sol", async () => {
                     ethers.utils.parseEther("5"),
                     1,
                 ]
-                let feeRate = ethers.BigNumber.from("0")
+                let feeRate = ethers.utils.parseEther("0.1")
                 let expected = getTradePosition(position, trade, feeRate)
+                // 5 units at $1, with a feeRate of 10% => $0.5 fee
+                // Starting base was $10; after the trade, goes up by $5 (5 units * $1 / unit)
+                // 10 + 5 - 0.5 = 14.5
+                expect(expected[0]).to.equal(ethers.utils.parseEther("14.5"))
                 let result = await libBalances.applyTrade(
                     position,
                     trade,


### PR DESCRIPTION
# Motivation
There was a logic error in fee subtraction from trades that slipped past code review during the lib refactor; the issue is that for long trades, the fee was being added to the quote of a user's position instead of subtracted. This pull request fixes that. 

Whether/how leveraged a trader is determined by the value of their absolute position minus their quote tokens. If the fee were to be added, then they would become less leveraged after the fee is applied (as that means their quote would increase but the notional value of their position would stay the same). In the same vein, having a fee that's subtracted from their quote makes them ever so slightly more leveraged. 

Fixes [this](https://github.com/code-423n4/2021-06-tracer-findings/issues/127).

# Changes
- Fix fee subtraction issue
- Corresponding changes to tests
- Some stylistic things in `LibBalances`
- Add coverage directory to `.prettierignore` (to avoid Hardhat-generated test coverage files from being linted)