### PR TITLE
Offset funding rate calculation by a factor of 8

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -39,6 +39,10 @@ contract Pricing is IPricing {
     uint256 public startLast24Hours;
     uint8 public override currentHour;
 
+    // The funding rate is supposed to be 8-hourly, but because it's paid hourly
+    // in the contracts, we offset the calculated rate by a factor of 8
+    int256 internal constant FUNDING_RATE_OFFSET = 8;
+
     event HourlyPriceUpdated(uint256 price, uint256 currentHour);
     event FundingRateUpdated(int256 fundingRate, int256 cumulativeFundingRate);
     event InsuranceFundingRateUpdated(int256 insuranceFundingRate, int256 insuranceFundingRateValue);
@@ -152,7 +156,7 @@ contract Pricing is IPricing {
         int256 newFundingRate = PRBMathSD59x18.mul(
             derivativeTWAP.toInt256() - underlyingTWAP.toInt256() - timeValue,
             _tracer.fundingRateSensitivity().toInt256()
-        );
+        ) / FUNDING_RATE_OFFSET;
 
         // Create variable with value of new funding rate value
         int256 currentFundingRateValue = fundingRates[currentFundingIndex].cumulativeFundingRate;

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -41,7 +41,7 @@ contract Pricing is IPricing {
 
     // The funding rate is supposed to be 8-hourly, but because it's paid hourly
     // in the contracts, we offset the calculated rate by a factor of 8
-    int256 internal constant FUNDING_RATE_OFFSET = 8;
+    int256 private constant FUNDING_RATE_OFFSET = 8;
 
     event HourlyPriceUpdated(uint256 price, uint256 currentHour);
     event FundingRateUpdated(int256 fundingRate, int256 cumulativeFundingRate);

--- a/test/functional/TracerPerpetualSwaps.js
+++ b/test/functional/TracerPerpetualSwaps.js
@@ -329,9 +329,9 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
 
                 // settle accounts and measure funding rate affect
                 // fundingRate = derivative twap - underlying twap - time value
-                // $1.1333 - $1 - 0 = 0.1333
+                // ($1.1333 - $1 - 0) / 8 = 0.16666666666666666
                 let expectedFundingRate = ethers.utils.parseEther(
-                    "0.133333333333333333"
+                    "0.016666666666666666"
                 )
                 fundingIndex = await pricing.currentFundingIndex()
                 let fundingRate = await pricing.fundingRates(fundingIndex - 1)


### PR DESCRIPTION
# Motivation

The funding rate is calculated on an eight-hourly basis, but is paid on an hourly basis. This PR offsets the funding rate calculation by a factor of eight to account for that. 

# Changes
- Add offset for funding rate calculation
- Change corresponding test