### PR TITLE
Mark state variables immutable where possible

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -17,10 +17,10 @@ contract Insurance is IInsurance {
     using LibMath for int256;
     ITracerPerpetualsFactory public perpsFactory;
 
-    address public collateralAsset; // Address of collateral asset
+    address public immutable collateralAsset; // Address of collateral asset
     uint256 public override publicCollateralAmount; // amount of underlying collateral in public pool, in WAD format
     uint256 public override bufferCollateralAmount; // amount of collateral in buffer pool, in WAD format
-    address public token; // token representation of a users holding in the pool
+    address public immutable token; // token representation of a users holding in the pool
 
     ITracerPerpetualSwaps public tracer; // Tracer associated with Insurance Pool
 

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -27,8 +27,8 @@ contract Liquidation is ILiquidation, Ownable {
     uint256 public override minimumLeftoverGasCostMultiplier = 10;
     IPricing public pricing;
     ITracerPerpetualSwaps public tracer;
-    address public insuranceContract;
-    address public fastGasOracle;
+    address public immutable insuranceContract;
+    address public immutable fastGasOracle;
 
     // Receipt ID => LiquidationReceipt
     mapping(uint256 => LibLiquidation.LiquidationReceipt) public liquidationReceipts;

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -14,7 +14,7 @@ contract Pricing is IPricing {
     using LibMath for int256;
     using PRBMathSD59x18 for int256;
 
-    address public tracer;
+    address public immutable tracer;
     IInsurance public insurance;
     IOracle public oracle;
 


### PR DESCRIPTION
# Motivation
During [the Code Arena audit](https://github.com/code-423n4/2021-06-tracer-findings), it was flagged (specifically in [#40](https://github.com/code-423n4/2021-06-tracer-findings/issues/40)) that some state variables are likely able to be marked as `immutable`.

# Changes
 - Mark `collateralAsset` in `Insurance.sol` as `immutable`
 - Mark `token` in `Insurance.sol` as `immutable`
 - Mark `insuranceContract` in `Liquidation.sol` as `immutable`
 - Mark `fastGasOracle` in `Liquidation.sol` as `immutable`
 - Mark `tracer` in `Pricing.sol` as `immutable`
