### PR TITLE
Refactor constants

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -30,6 +30,9 @@ contract Insurance is IInsurance {
     // 0.00000570775 as a WAD = 570775 * (10 ** 7)
     uint256 private constant INSURANCE_FUNDING_RATE_FACTOR = 570775 * (10**7);
 
+    // Target percent of leveraged notional value in the market for the insurance pool to meet; 1% by default
+    uint256 private constant INSURANCE_POOL_TARGET_PERCENT = 1e16;
+
     ITracerPerpetualSwaps public tracer; // Tracer associated with Insurance Pool
 
     event InsuranceDeposit(address indexed market, address indexed user, uint256 indexed amount);
@@ -202,7 +205,7 @@ contract Insurance is IInsurance {
      * @dev The target amount is 1% of the leveraged notional value of the tracer being insured.
      */
     function getPoolTarget() public view override returns (uint256) {
-        return tracer.leveragedNotionalValue() / 100;
+        return PRBMathUD60x18.mul(tracer.leveragedNotionalValue(), INSURANCE_POOL_TARGET_PERCENT);
     }
 
     /**

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -22,6 +22,8 @@ contract Insurance is IInsurance {
     uint256 public override bufferCollateralAmount; // amount of collateral in buffer pool, in WAD format
     address public token; // token representation of a users holding in the pool
 
+    uint256 private constant ONE_TOKEN = 1e18; // Constant for 10**18, i.e. one token in WAD format; used for drainPool
+
     ITracerPerpetualSwaps public tracer; // Tracer associated with Insurance Pool
 
     event InsuranceDeposit(address indexed market, address indexed user, uint256 indexed amount);
@@ -139,10 +141,10 @@ contract Insurance is IInsurance {
 
         if (amount >= poolHoldings) {
             // If public collateral left after draining is less than 1 token, we want to keep it at 1 token
-            if (publicCollateralAmount > 10**18) {
+            if (publicCollateralAmount > ONE_TOKEN) {
                 // Leave 1 token for the public pool
-                amount = poolHoldings - 10**18;
-                publicCollateralAmount = 10**18;
+                amount = poolHoldings - ONE_TOKEN;
+                publicCollateralAmount = ONE_TOKEN;
             } else {
                 amount = bufferCollateralAmount;
             }
@@ -150,14 +152,14 @@ contract Insurance is IInsurance {
             // Drain buffer
             bufferCollateralAmount = 0;
         } else if (amount > bufferCollateralAmount) {
-            if (publicCollateralAmount < 10**18) {
+            if (publicCollateralAmount < ONE_TOKEN) {
                 // If there's not enough public collateral for there to be 1 token, cap amount being drained at the buffer
                 amount = bufferCollateralAmount;
-            } else if (poolHoldings - amount < 10**18) {
+            } else if (poolHoldings - amount < ONE_TOKEN) {
                 // If the amount of collateral left in the public insurance would be less than 1 token, cap amount being drained
                 // from the public insurance such that 1 token is left in the public buffer
-                amount = poolHoldings - 10**18;
-                publicCollateralAmount = 10**18;
+                amount = poolHoldings - ONE_TOKEN;
+                publicCollateralAmount = ONE_TOKEN;
             } else {
                 // Take out what you need from the public pool; there's enough for there to be >= 1 token left
                 publicCollateralAmount = publicCollateralAmount - (amount - bufferCollateralAmount);

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -14,6 +14,7 @@ library Balances {
     using PRBMathUD60x18 for uint256;
 
     uint256 public constant MAX_DECIMALS = 18;
+    uint256 private constant LIQUIDATION_GAS_MULTIPLIER = 6;
 
     // Size of a position
     struct Position {
@@ -111,7 +112,7 @@ library Balances {
             return 0;
         }
 
-        uint256 adjustedLiquidationGasCost = liquidationGasCost * 6;
+        uint256 adjustedLiquidationGasCost = liquidationGasCost * LIQUIDATION_GAS_MULTIPLIER;
 
         uint256 _notionalValue = notionalValue(position, price);
         uint256 minimumMarginWithoutGasCost = PRBMathUD60x18.div(_notionalValue, maximumLeverage);

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 import "prb-math/contracts/PRBMathUD60x18.sol";
 
 library Perpetuals {
+    uint256 private constant PERCENT_MULTIPLIER = 100;
+
     // Sides that an order can take
     enum Side {
         Long,
@@ -75,7 +77,7 @@ library Perpetuals {
             return lowestMaxLeverage;
         }
         uint256 percentFull = PRBMathUD60x18.div(collateralAmount, poolTarget);
-        percentFull = percentFull * 100; // To bring it up to the same percentage units as everything else
+        percentFull = percentFull * PERCENT_MULTIPLIER; // To bring it up to the same percentage units as everything else
 
         if (percentFull >= deleveragingCliff) {
             return defaultMaxLeverage;

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -9,6 +9,8 @@ import "prb-math/contracts/PRBMathSD59x18.sol";
 library Prices {
     using LibMath for uint256;
 
+    uint256 private constant EIGHT_HOURS = 8; // Needed for TWAP calculations
+
     struct FundingRateInstant {
         uint256 timestamp;
         int256 fundingRate;
@@ -120,8 +122,8 @@ library Prices {
         uint256 cumulativeDerivative = 0;
         uint256 cumulativeUnderlying = 0;
 
-        for (uint256 i = 0; i < 8; i++) {
-            uint256 currTimeWeight = 8 - i;
+        for (uint256 i = 0; i < EIGHT_HOURS; i++) {
+            uint256 currTimeWeight = EIGHT_HOURS - i;
             // if hour < i loop back towards 0 from 23.
             // otherwise move from hour towards 0
             uint256 j = hour < i ? 24 - i + hour : hour - i;

--- a/contracts/lib/LibPrices.sol
+++ b/contracts/lib/LibPrices.sol
@@ -10,6 +10,7 @@ library Prices {
     using LibMath for uint256;
 
     uint256 private constant EIGHT_HOURS = 8; // Needed for TWAP calculations
+    int256 private constant NINETY_DAYS = 90; // Needed for daily time value calculation
 
     struct FundingRateInstant {
         uint256 timestamp;
@@ -32,7 +33,7 @@ library Prices {
     }
 
     function timeValue(uint256 averageTracerPrice, uint256 averageOraclePrice) internal pure returns (int256) {
-        return (averageTracerPrice.toInt256() - averageOraclePrice.toInt256()) / 90;
+        return (averageTracerPrice.toInt256() - averageOraclePrice.toInt256()) / NINETY_DAYS;
     }
 
     /**


### PR DESCRIPTION
# Motivation 
There appear to be some marginal gas improvements to having constants in contracts instead of Solidity's inlined numbers (see [here](https://github.com/jmcph4/solidity-inlined-constants)). This PR refactors such variables in the contracts. This also makes it less magic number-y. 

EDIT: I was only going to factor out the constants in the insurance contract initially, but increased the scope to all the contracts, thus the bad branch name :c

# Changes
- Refactor numbers in the contracts as constants.