### PR TITLE
Refactored liquidation contract

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -111,7 +111,7 @@ contract Liquidation is ILiquidation, Ownable {
      * @notice Allows a trader to claim escrowed funds after the escrow period has expired
      * @param receiptId The ID number of the insurance receipt from which funds are being claimed from
      */
-    function claimEscrow(uint256 receiptId) public override {
+    function claimEscrow(uint256 receiptId) external override {
         LibLiquidation.LiquidationReceipt memory receipt = liquidationReceipts[receiptId];
         require(!receipt.escrowClaimed, "LIQ: Escrow claimed");
         require(block.timestamp > receipt.releaseTime, "LIQ: Not released");

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -164,20 +164,12 @@ contract Liquidation is ILiquidation, Ownable {
         uint256 gasCost = gasPrice * tracer.LIQUIDATION_GAS_COST();
 
         int256 currentMargin = Balances.margin(pos, price);
-        require(
-            currentMargin <= 0 ||
-                uint256(currentMargin) < Balances.minimumMargin(pos, price, gasCost, tracer.trueMaxLeverage()),
-            "LIQ: Account above margin"
-        );
+        uint256 minimumMargin = Balances.minimumMargin(pos, price, gasCost, tracer.trueMaxLeverage());
+        require(currentMargin <= 0 || uint256(currentMargin) < minimumMargin, "LIQ: Account above margin");
         require(amount <= base.abs(), "LIQ: Liquidate Amount > Position");
 
         // calc funds to liquidate and move to Escrow
-        uint256 amountToEscrow = LibLiquidation.calcEscrowLiquidationAmount(
-            Balances.minimumMargin(pos, price, gasCost, tracer.trueMaxLeverage()),
-            currentMargin,
-            amount,
-            base
-        );
+        uint256 amountToEscrow = LibLiquidation.calcEscrowLiquidationAmount(minimumMargin, currentMargin, amount, base);
 
         // create a liquidation receipt
         Perpetuals.Side side = base < 0 ? Perpetuals.Side.Short : Perpetuals.Side.Long;

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -108,7 +108,7 @@ contract Liquidation is ILiquidation, Ownable {
     }
 
     /**
-     * @notice Allows a trader to claim escrowed funds after the escrow period has expired
+     * @notice Transfers the escrowed funds to the trader if the escrow period has expired. Can be called by anyone.
      * @param receiptId The ID number of the insurance receipt from which funds are being claimed from
      */
     function claimEscrow(uint256 receiptId) external override {


### PR DESCRIPTION
# Motivation
Note the branch is incorrectly named as claim-escrow but involves refactoring changes to the liquidation contract.

The claimEscrow() function can be changed to external for gas savings and clarity.

The claimEscrow() comment also states that only a trader can call the function, however anyone can call the function.

Gas savings in verifyAndSubmitLiquidation() due to minimumMargin variable being calculated twice.

# Changes
- claimEscrow() function changed from public to external (code-423n4/2021-06-tracer-findings#128).
- claimEscrow() comment updated (code-423n4/2021-06-tracer-findings#26).
- saved the minimumMargin variable to memory to reduce gas (code-423n4/2021-06-tracer-findings#131).