### PR TITLE
Remove insurance constructor event

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -26,7 +26,6 @@ contract Insurance is IInsurance {
 
     event InsuranceDeposit(address indexed market, address indexed user, uint256 indexed amount);
     event InsuranceWithdraw(address indexed market, address indexed user, uint256 indexed amount);
-    event InsurancePoolDeployed(address indexed market, address indexed asset);
 
     constructor(address _tracer) {
         require(_tracer != address(0), "INS: _tracer = address(0)");
@@ -34,9 +33,7 @@ contract Insurance is IInsurance {
         InsurancePoolToken _token = new InsurancePoolToken("Tracer Pool Token", "TPT");
         token = address(_token);
         collateralAsset = tracer.tracerQuoteToken();
-
-        emit InsurancePoolDeployed(_tracer, tracer.tracerQuoteToken());
-    }
+        }
 
     /**
      * @notice Allows a user to deposit to a given tracer market insurance pool

--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -33,7 +33,7 @@ contract Insurance is IInsurance {
         InsurancePoolToken _token = new InsurancePoolToken("Tracer Pool Token", "TPT");
         token = address(_token);
         collateralAsset = tracer.tracerQuoteToken();
-        }
+    }
 
     /**
      * @notice Allows a user to deposit to a given tracer market insurance pool


### PR DESCRIPTION
# Motivation
There is inconsistency in the use of events for contract constructors. Insurance contains an event in its constructor, but no other contracts do (code-423n4/2021-06-tracer-findings#10).

# Changes
The insurance constructor event has been removed. All other contracts can be referenced from the Tracer, which has an event emitted from the factory. 