### PR TITLE
Ensure GasOracle latestAnswer() is in WAD format

### DIFF
--- a/contracts/oracle/GasOracle.sol
+++ b/contracts/oracle/GasOracle.sol
@@ -18,6 +18,7 @@ contract GasOracle is IOracle, Ownable {
     IChainlinkOracle public priceOracle;
     uint8 public override decimals = 18;
     uint256 private constant MAX_DECIMALS = 18;
+    uint256 private constant MAX_GWEI_DECIMALS = 9;
 
     constructor(address _priceOracle, address _gasOracle) {
         require(_gasOracle != address(0), "GasOracle: _gasOracle == 0");
@@ -31,26 +32,34 @@ contract GasOracle is IOracle, Ownable {
      * @dev Returned value is USD/Gas * 10^18 for compatibility with rest of calculations
      */
     function latestAnswer() external view override returns (uint256) {
-        uint256 gasPrice = uint256(gasOracle.latestAnswer());
-        uint256 ethPrice = uint256(priceOracle.latestAnswer());
+        uint256 gasPrice = _gasPriceToWad();
+        uint256 ethPrice = _ethPriceToWad();
 
         uint256 result = PRBMathUD60x18.mul(gasPrice, ethPrice);
         return result;
     }
 
     /**
-     * @notice converts a raw value to a WAD value.
-     * @dev this allows consistency for oracles used throughout the protocol
-     *      and allows oracles to have their decimals changed withou affecting
-     *      the market itself
+     * @notice Returns the latest answer from the Fast Gas/Gwei oracle in WAD format (Gwei/Gas * 10^18).
+     * @dev Since the answer is provided in Gwei, the number is scaled to 9 decimals to convert to WAD.
      */
-    function toWad(uint256 raw, IChainlinkOracle _oracle) internal view returns (uint256) {
-        IChainlinkOracle oracle = IChainlinkOracle(_oracle);
-        // reset the scaler for consistency
-        uint8 _decimals = oracle.decimals(); // 9
+    function _gasPriceToWad() internal view returns (uint256) {
+        uint256 result = uint256(gasOracle.latestAnswer());
+        uint8 _decimals = gasOracle.decimals();
+        require(_decimals <= MAX_GWEI_DECIMALS, "GAS: too many decimals");
+        uint256 scaler = uint256(10**(MAX_GWEI_DECIMALS - _decimals));
+        return result * scaler;
+    }
+
+    /**
+     * @notice Returns the latest answer from the ETH/USD oracle in WAD format (USD/ETH * 10^18).
+     */
+    function _ethPriceToWad() internal view returns (uint256) {
+        uint256 result = uint256(priceOracle.latestAnswer());
+        uint8 _decimals = priceOracle.decimals();
         require(_decimals <= MAX_DECIMALS, "GAS: too many decimals");
         uint256 scaler = uint256(10**(MAX_DECIMALS - _decimals));
-        return raw * scaler;
+        return result * scaler;
     }
 
     function setGasOracle(address _gasOracle) public nonZeroAddress(_gasOracle) onlyOwner {


### PR DESCRIPTION
# Motivation
The latestAnswer() function assumes that oracle latest answer returns values in WAD format. This may not necessarily be true, an explicit check and conversion should be added (code-423n4/2021-06-tracer-findings#93).

# Changes
- Added two functions that check oracle answer decimals. Function will revert if max number of decimals is exceeded in answer (i.e number provided with more than 18 decimals). Otherwise number is scaled up to 18 decimals to convert to WAD.