### PR TITLE
Add market check for order matching and fix linter errors

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -139,7 +139,7 @@ contract Insurance is IInsurance {
      *      This was done because in such an emergency situation, we want to recover as much as possible
      * @param amount The desired amount to take from the insurance pool
      */
-    function drainPool(uint256 amount) external override onlyLiquidation() {
+    function drainPool(uint256 amount) external override onlyLiquidation {
         IERC20 tracerMarginToken = IERC20(tracer.tracerQuoteToken());
 
         uint256 poolHoldings = getPoolHoldings();

--- a/contracts/InsurancePoolToken.sol
+++ b/contracts/InsurancePoolToken.sol
@@ -7,11 +7,11 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract InsurancePoolToken is ERC20, Ownable, ERC20Burnable {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 
-    function mint(address to, uint256 amount) external onlyOwner() {
+    function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);
     }
 
-    function burnFrom(address from, uint256 amount) public override onlyOwner() {
+    function burnFrom(address from, uint256 amount) public override onlyOwner {
         // override the burnFrom function and allow only the owner to burn
         // pool tokens on behalf of a holder
         _burn(from, amount);

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -454,7 +454,7 @@ contract Liquidation is ILiquidation, Ownable {
      * @notice Modifies the release time
      * @param _releaseTime new release time
      */
-    function setReleaseTime(uint256 _releaseTime) external onlyOwner() {
+    function setReleaseTime(uint256 _releaseTime) external onlyOwner {
         releaseTime = _releaseTime;
     }
 
@@ -463,7 +463,7 @@ contract Liquidation is ILiquidation, Ownable {
      *         the minimum leftover margin on partial liquidation
      * @param _minimumLeftoverGasCostMultiplier The new multiplier
      */
-    function setMinimumLeftoverGasCostMultiplier(uint256 _minimumLeftoverGasCostMultiplier) external onlyOwner() {
+    function setMinimumLeftoverGasCostMultiplier(uint256 _minimumLeftoverGasCostMultiplier) external onlyOwner {
         minimumLeftoverGasCostMultiplier = _minimumLeftoverGasCostMultiplier;
     }
 
@@ -471,7 +471,7 @@ contract Liquidation is ILiquidation, Ownable {
      * @notice Modifies the max slippage
      * @param _maxSlippage new max slippage
      */
-    function setMaxSlippage(uint256 _maxSlippage) public override onlyOwner() {
+    function setMaxSlippage(uint256 _maxSlippage) public override onlyOwner {
         maxSlippage = _maxSlippage;
     }
 

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -226,6 +226,7 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
         Perpetuals.Order memory order2,
         uint256 fillAmount
     ) external override onlyWhitelisted returns (bool) {
+        require(order1.market == address(this), "TCR: Wrong market");
         bytes32 order1Id = Perpetuals.orderId(order1);
         bytes32 order2Id = Perpetuals.orderId(order2);
         uint256 filled1 = ITrader(msg.sender).filled(order1Id);

--- a/contracts/TracerPerpetualsFactory.sol
+++ b/contracts/TracerPerpetualsFactory.sol
@@ -65,7 +65,7 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
         address oracle,
         address fastGasOracle,
         uint256 maxLiquidationSlippage
-    ) external onlyOwner() {
+    ) external onlyOwner {
         address tracer = _deployTracer(_data, owner(), oracle, fastGasOracle, maxLiquidationSlippage);
         // DAO deployed markets are automatically approved
         setApproved(address(tracer), true);
@@ -116,7 +116,7 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
      * @notice Sets the perpsDeployer contract for tracers markets.
      * @param newDeployer the new perpsDeployer contract address
      */
-    function setPerpsDeployerContract(address newDeployer) public override nonZeroAddress(newDeployer) onlyOwner() {
+    function setPerpsDeployerContract(address newDeployer) public override nonZeroAddress(newDeployer) onlyOwner {
         perpsDeployer = newDeployer;
     }
 
@@ -124,7 +124,7 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
         public
         override
         nonZeroAddress(newInsuranceDeployer)
-        onlyOwner()
+        onlyOwner
     {
         insuranceDeployer = newInsuranceDeployer;
     }
@@ -133,7 +133,7 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
         public
         override
         nonZeroAddress(newPricingDeployer)
-        onlyOwner()
+        onlyOwner
     {
         pricingDeployer = newPricingDeployer;
     }
@@ -142,7 +142,7 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
         public
         override
         nonZeroAddress(newLiquidationDeployer)
-        onlyOwner()
+        onlyOwner
     {
         liquidationDeployer = newLiquidationDeployer;
     }
@@ -157,7 +157,7 @@ contract TracerPerpetualsFactory is Ownable, ITracerPerpetualsFactory {
      *         identify contracts that the DAO has "absorbed" into its control
      * @dev requires the contract to be owned by the DAO if being set to true.
      */
-    function setApproved(address market, bool value) public override onlyOwner() {
+    function setApproved(address market, bool value) public override onlyOwner {
         if (value) {
             require(Ownable(market).owner() == owner(), "TFC: Owner not DAO");
         }

--- a/contracts/test/LibLiquidationMock.sol
+++ b/contracts/test/LibLiquidationMock.sol
@@ -29,7 +29,7 @@ library LibLiquidationMock {
         )
     {
         (_liquidatorQuoteChange, _liquidatorBaseChange, _liquidateeQuoteChange, _liquidateeBaseChange) = LibLiquidation
-        .liquidationBalanceChanges(liquidatedBase, liquidatedQuote, amount);
+            .liquidationBalanceChanges(liquidatedBase, liquidatedQuote, amount);
     }
 
     function calculateSlippage(


### PR DESCRIPTION
# Motivation
The matchOrders function never checks that the market is correct. The Trader contract that calls it deals with multiple markets so it is possible that an order may be mistakenly sent with the wrong market. Only the market of 1 order needs to be checked since the canMatch function checks that the markets of the orders equal each other. (code-423n4/2021-06-tracer-findings#6)

# Changes
- add check for order market in order matching
- fix linter errors