### PR TITLE
LibBalance C4 changes

### DIFF
--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -227,6 +227,6 @@ library Balances {
      */
     function wadToToken(uint256 tokenDecimals, uint256 wadAmount) internal pure returns (uint256) {
         uint256 scaler = uint256(10**(MAX_DECIMALS - tokenDecimals));
-        return uint256(wadAmount / scaler);
+        return wadAmount / scaler;
     }
 }

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -218,7 +218,7 @@ library Balances {
      * that don't have 18 decimal places
      */
     function tokenToWad(uint256 tokenDecimals, uint256 amount) internal pure returns (int256) {
-        require(tokenDecimals <= 18, "Max decimals exceeded");
+        require(tokenDecimals <= MAX_DECIMALS, "Max decimals exceeded");
         uint256 scaler = 10**(MAX_DECIMALS - tokenDecimals);
         return amount.toInt256() * scaler.toInt256();
     }
@@ -227,8 +227,8 @@ library Balances {
      * @notice Converts a wad token amount to its raw representation.
      */
     function wadToToken(uint256 tokenDecimals, uint256 wadAmount) internal pure returns (uint256) {
-        require(tokenDecimals <= 18, "Max decimals exceeded");
-        uint256 scaler = uint256(10**(MAX_DECIMALS - tokenDecimals));
+        require(tokenDecimals <= MAX_DECIMALS, "Max decimals exceeded");
+        uint256 scaler = 10**(MAX_DECIMALS - tokenDecimals);
         return wadAmount / scaler;
     }
 }

--- a/contracts/lib/LibBalances.sol
+++ b/contracts/lib/LibBalances.sol
@@ -218,6 +218,7 @@ library Balances {
      * that don't have 18 decimal places
      */
     function tokenToWad(uint256 tokenDecimals, uint256 amount) internal pure returns (int256) {
+        require(tokenDecimals <= 18, "Max decimals exceeded");
         uint256 scaler = 10**(MAX_DECIMALS - tokenDecimals);
         return amount.toInt256() * scaler.toInt256();
     }
@@ -226,6 +227,7 @@ library Balances {
      * @notice Converts a wad token amount to its raw representation.
      */
     function wadToToken(uint256 tokenDecimals, uint256 wadAmount) internal pure returns (uint256) {
+        require(tokenDecimals <= 18, "Max decimals exceeded");
         uint256 scaler = uint256(10**(MAX_DECIMALS - tokenDecimals));
         return wadAmount / scaler;
     }


### PR DESCRIPTION
# Motivation
Addresses code-423n4/2021-06-tracer-findings#118
Addresses code-423n4/2021-06-tracer-findings#116

# Changes
- Removed unnecessary type cast in wadToToken, both values were uint256
- Added decimal checks to ensure maximum of 18 decimals is enforced