### PR TITLE
Mark variables as immutable

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -16,10 +16,10 @@ contract Insurance is IInsurance {
     using LibMath for uint256;
     using LibMath for int256;
 
-    address public collateralAsset; // Address of collateral asset
+    address public immutable collateralAsset; // Address of collateral asset
     uint256 public override publicCollateralAmount; // amount of underlying collateral in public pool, in WAD format
     uint256 public override bufferCollateralAmount; // amount of collateral in buffer pool, in WAD format
-    address public token; // token representation of a users holding in the pool
+    address public immutable token; // token representation of a users holding in the pool
 
     uint256 private constant ONE_TOKEN = 1e18; // Constant for 10**18, i.e. one token in WAD format; used for drainPool
 

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -25,10 +25,10 @@ contract Liquidation is ILiquidation, Ownable {
     uint256 public override maxSlippage;
     uint256 public override releaseTime = 15 minutes;
     uint256 public override minimumLeftoverGasCostMultiplier = 10;
-    IPricing public pricing;
-    ITracerPerpetualSwaps public tracer;
-    address public insuranceContract;
-    address public fastGasOracle;
+    IPricing public immutable pricing;
+    ITracerPerpetualSwaps public immutable tracer;
+    address public immutable insuranceContract;
+    address public immutable fastGasOracle;
 
     // Receipt ID => LiquidationReceipt
     mapping(uint256 => LibLiquidation.LiquidationReceipt) public liquidationReceipts;

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -15,9 +15,9 @@ contract Pricing is IPricing {
     using LibMath for int256;
     using PRBMathSD59x18 for int256;
 
-    address public tracer;
-    IInsurance public insurance;
-    IOracle public oracle;
+    address public immutable tracer;
+    IInsurance public immutable insurance;
+    IOracle public immutable oracle;
 
     // pricing metrics
     Prices.PriceInstant[24] internal hourlyTracerPrices;


### PR DESCRIPTION
# Motivation
Gas savings by marking variables as immutable code-423n4/2021-06-tracer-findings#24

# Changes
Mark existing variables noted in issue as immutable. 3 Variables were not changed:
- openzeppelin/contracts/token/ERC20/ERC20.sol:38:5: uint256 private _totalSupply; External to codebase
- contracts/Insurance.sol:18:5: ITracerPerpetualsFactory public perpsFactory; Variable deleted since audit
- contracts/Insurance.sol:25:5: ITracerPerpetualSwaps public tracer; Variable used at contract creation time and cannot be changed to immutable