### PR TITLE
Remove redundant decimals function

### DIFF
--- a/contracts/Interfaces/README_Interfaces_Overview.md
+++ b/contracts/Interfaces/README_Interfaces_Overview.md
@@ -50,14 +50,14 @@ IInsurance.sol is an interface that describes the functions that an Insurance co
 => The Insurance Pool Token implementation can be found in InsurancePoolToken.sol 
 
 **IOracle.sol**   
-IOracle.sol is an interface that describes the functions that an Oracle Feed contract should implement.   
+IOracle.sol is an interface that describes the functions that an Oracle Feed contract should implement.  
 =>The specific implementation of this interface as a contract can be found in GasOracle.sol (An example an oracle that references Chainlink fast gas price and ETH/USD price to get a gas cost in $USD  
-**Explanation:** This interface described the minimum functionality that a Tracer/Gas Oracle need to have. Each oracle can have different implementations (although they must conform to IOracle.sol), the Oracle must be community approved. Chainlink feed contracts (excluding the Fast Gas / GWEI feed) must be wrapped in a Tracer Chainlink Adapter which conforms to the IOracle specification (ChainlinkOracleAdapter.sol).
+**Explanation:** This interface described the minimum functionality that a Tracer/Gas Oracle need to have. Its purpose is to standardise the decimals provided by all Oracles answers in the system (initially 18 decimals). Each oracle can have different implementations (although they must conform to IOracle.sol), the Oracle must be community approved. All Chainlink feed contracts (excluding the Fast Gas / GWEI feed) must be wrapped in a Tracer Chainlink Adapter which conforms to the IOracle specification (ChainlinkOracleAdapter.sol).
 
 **IReceipt.sol**   
 IReceipt.sol is an interface that describes the functions that a Receipt contract should implement.   
 =>The specific implementation of this interface as a contract can be found in Receipt.sol   
-**Explanation:** The receipt contract handles the creation of liquidation  receipts and retrieval  of funds entitled to entities who facilitate a complete and successful liquidation ; 
+**Explanation:** The receipt contract handles the creation of liquidation  receipts and retrieval of funds entitled to entities who facilitate a complete and successful liquidation ; 
 
 **ITracerPerpetualSwaps.sol**   
 ITracerPerpetualSwaps.sol is an interface that describes the functions that a Tracer contract should implement.   

--- a/contracts/oracle/ChainlinkOracle.sol
+++ b/contracts/oracle/ChainlinkOracle.sol
@@ -13,8 +13,8 @@ import "../Interfaces/IChainlinkOracle.sol";
 contract ChainlinkOracle is IChainlinkOracle {
     int256 public price = 100000000;
     uint8 public override decimals = 8; // default of 8 decimals for USD price feeds in the Chainlink ecosystem
-    string public override description = "A mock Chainlink V3 Aggregator";
-    uint256 public override version = 3; // Aggregator V3;
+    string public constant override description = "A mock Chainlink V3 Aggregator";
+    uint256 public constant override version = 3; // Aggregator V3;
     uint80 private constant ROUND_ID = 1; // A mock round Id
 
     /**

--- a/contracts/oracle/GasOracle.sol
+++ b/contracts/oracle/GasOracle.sol
@@ -16,7 +16,6 @@ contract GasOracle is IOracle, Ownable {
     using LibMath for uint256;
     IChainlinkOracle public gasOracle;
     IChainlinkOracle public priceOracle;
-    uint8 public override decimals = 18;
     uint256 private constant MAX_DECIMALS = 18;
     uint256 private constant MAX_GWEI_DECIMALS = 9;
 
@@ -66,16 +65,19 @@ contract GasOracle is IOracle, Ownable {
         return uint256(price) * scaler;
     }
 
+    /**
+     * @notice Returns the number of decimals in answers provided by the Oracle
+     */
+    function decimals() external pure override returns (uint8) {
+        return uint8(MAX_DECIMALS);
+    }
+
     function setGasOracle(address _gasOracle) public nonZeroAddress(_gasOracle) onlyOwner {
         gasOracle = IChainlinkOracle(_gasOracle);
     }
 
     function setPriceOracle(address _priceOracle) public nonZeroAddress(_priceOracle) onlyOwner {
         priceOracle = IChainlinkOracle(_priceOracle);
-    }
-
-    function setDecimals(uint8 _decimals) external {
-        decimals = _decimals;
     }
 
     modifier nonZeroAddress(address providedAddress) {

--- a/scripts/SetPrice.js
+++ b/scripts/SetPrice.js
@@ -1,4 +1,4 @@
-const oracleAbi = require("../abi/contracts/oracle/Oracle.sol/Oracle.json")
+const oracleAbi = require("../abi/contracts/oracle/ChainlinkOracle.sol/ChainlinkOracle.json")
 const { Command } = require("commander")
 const hre = require("hardhat")
 const fs = require("fs")


### PR DESCRIPTION
# Motivation
GasOracle contains redundant `setDecimals` function and unused `decimals` variable.

# Changes
- Remove `setDecimals` function
- Implement `decimals` function
