### PR TITLE
Liquidation updates from C4 feedback

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -112,7 +112,7 @@ contract Liquidation is ILiquidation, Ownable {
         require(receiptId < currentLiquidationId, "LIQ: Invalid receipt");
         LibLiquidation.LiquidationReceipt memory receipt = liquidationReceipts[receiptId];
         require(!receipt.escrowClaimed, "LIQ: Escrow claimed");
-        require(block.timestamp > receipt.releaseTime, "LIQ: Not released");
+        require(block.timestamp >= receipt.releaseTime, "LIQ: Not released");
 
         // Mark as claimed
         liquidationReceipts[receiptId].escrowClaimed = true;
@@ -399,7 +399,7 @@ contract Liquidation is ILiquidation, Ownable {
         require(!receipt.liquidatorRefundClaimed, "LIQ: Already claimed");
         liquidationReceipts[receiptId].liquidatorRefundClaimed = true;
         liquidationReceipts[receiptId].escrowClaimed = true;
-        require(block.timestamp < receipt.releaseTime, "LIQ: claim time passed");
+        require(block.timestamp <= receipt.releaseTime, "LIQ: claim time passed");
         require(tracer.tradingWhitelist(traderContract), "LIQ: Trader is not whitelisted");
 
         uint256 amountToReturn = calcAmountToReturn(receiptId, orders, traderContract);

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -162,7 +162,7 @@ contract Liquidation is ILiquidation, Ownable {
 
         int256 currentMargin = Balances.margin(pos, price);
         uint256 minimumMargin = Balances.minimumMargin(pos, price, gasCost, tracer.trueMaxLeverage());
-        require(currentMargin <= 0 || uint256(currentMargin) < minimumMargin, "LIQ: Account above margin");
+        require(currentMargin <= 0 || uint256(currentMargin) <= minimumMargin, "LIQ: Account above margin");
         require(amount <= base.abs(), "LIQ: Liquidate Amount > Position");
 
         // calc funds to liquidate and move to Escrow

--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -109,6 +109,7 @@ contract Liquidation is ILiquidation, Ownable {
      * @param receiptId The ID number of the insurance receipt from which funds are being claimed from
      */
     function claimEscrow(uint256 receiptId) external override {
+        require(receiptId < currentLiquidationId, "LIQ: Invalid receipt");
         LibLiquidation.LiquidationReceipt memory receipt = liquidationReceipts[receiptId];
         require(!receipt.escrowClaimed, "LIQ: Escrow claimed");
         require(block.timestamp > receipt.releaseTime, "LIQ: Not released");

--- a/test/functional/Liquidation.js
+++ b/test/functional/Liquidation.js
@@ -1341,6 +1341,17 @@ describe("Liquidation functional tests", async () => {
             await network.provider.send("evm_mine", [])
         }
 
+        context("when receipt does not exist", async () => {
+            it("Reverts ", async () => {
+                const contracts = await setupReceiptTest()
+                accounts = await ethers.getSigners()
+                const tx = contracts.liquidation
+                    .connect(accounts[0])
+                    .claimEscrow(1)
+                await expect(tx).to.be.revertedWith("LIQ: Invalid receipt")
+            })
+        })
+
         context(
             "when receipt already claimed through claimEscrow",
             async () => {


### PR DESCRIPTION
# Motivation
C4 audit identified gas savings and incorrect logic with liquidation contract 

# Changes
Validate receipt Id's in `claimEscrow` (https://github.com/code-423n4/2021-06-tracer-findings/issues/107)
- Check that `receiptId` is < `currentLiquidationId`
- Add unit test

Amend `amountTakenFromInsurance` calculation to be inclusive (https://github.com/code-423n4/2021-06-tracer-findings/issues/108)
- Updated to `amountToReturn >= receipt.escrowedAmount`
- Move liquidationReceipt update into existing if statement

Amend minimumMargin calculation to be inclusive (https://github.com/code-423n4/2021-06-tracer-findings/issues/109)
- Updated to `uint256(currentMargin) <= minimumMargin`

Convert time ranges to open-ended (https://github.com/code-423n4/2021-06-tracer-findings/issues/75)
- Include start and end times as part of release time by changing checks to be inclusive