### PR TITLE
Use external modifier where possible

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -467,7 +467,7 @@ contract Liquidation is ILiquidation, Ownable {
      * @notice Modifies the max slippage
      * @param _maxSlippage new max slippage
      */
-    function setMaxSlippage(uint256 _maxSlippage) public override onlyOwner {
+    function setMaxSlippage(uint256 _maxSlippage) external override onlyOwner {
         maxSlippage = _maxSlippage;
     }
 

--- a/contracts/lib/LibLiquidation.sol
+++ b/contracts/lib/LibLiquidation.sol
@@ -65,7 +65,7 @@ library LibLiquidation {
         int256 liquidatedQuote, //10^18
         int256 amount //10^18
     )
-        public
+        external
         pure
         returns (
             int256 _liquidatorQuoteChange,

--- a/contracts/oracle/ChainlinkOracle.sol
+++ b/contracts/oracle/ChainlinkOracle.sol
@@ -46,7 +46,7 @@ contract ChainlinkOracle is IChainlinkOracle {
     /**
      * @notice Sets the answer that is returned by the Oracle when latestRoundData is called
      */
-    function setPrice(int256 _price) public {
+    function setPrice(int256 _price) external {
         price = _price;
     }
 

--- a/contracts/oracle/ChainlinkOracleAdapter.sol
+++ b/contracts/oracle/ChainlinkOracleAdapter.sol
@@ -52,7 +52,7 @@ contract OracleAdapter is IOracle, Ownable {
     /**
      * @notice Change the upstream feed address.
      */
-    function changeOracle(address newOracle) public onlyOwner {
+    function changeOracle(address newOracle) external onlyOwner {
         setOracle(newOracle);
     }
 

--- a/contracts/oracle/GasOracle.sol
+++ b/contracts/oracle/GasOracle.sol
@@ -66,11 +66,11 @@ contract GasOracle is IOracle, Ownable {
         return uint256(price) * scaler;
     }
 
-    function setGasOracle(address _gasOracle) public nonZeroAddress(_gasOracle) onlyOwner {
+    function setGasOracle(address _gasOracle) external nonZeroAddress(_gasOracle) onlyOwner {
         gasOracle = IChainlinkOracle(_gasOracle);
     }
 
-    function setPriceOracle(address _priceOracle) public nonZeroAddress(_priceOracle) onlyOwner {
+    function setPriceOracle(address _priceOracle) external nonZeroAddress(_priceOracle) onlyOwner {
         priceOracle = IChainlinkOracle(_priceOracle);
     }
 

--- a/contracts/test/LibInsuranceMock.sol
+++ b/contracts/test/LibInsuranceMock.sol
@@ -8,7 +8,7 @@ library LibInsuranceMock {
         uint256 poolTokenSupply, // the total circulating supply of pool tokens
         uint256 poolTokenUnderlying, // the holding of the insurance pool in quote tokens
         uint256 wadAmount //the WAD amount of tokens being deposited
-    ) public pure returns (uint256) {
+    ) external pure returns (uint256) {
         return LibInsurance.calcMintAmount(poolTokenSupply, poolTokenUnderlying, wadAmount);
     }
 
@@ -16,7 +16,7 @@ library LibInsuranceMock {
         uint256 poolTokenSupply, // the total circulating supply of pool tokens
         uint256 poolTokenUnderlying, // the holding of the insurance pool in quote tokens
         uint256 wadAmount //the WAD amount of tokens being deposited
-    ) public pure returns (uint256) {
+    ) external pure returns (uint256) {
         return LibInsurance.calcWithdrawAmount(poolTokenSupply, poolTokenUnderlying, wadAmount);
     }
 }

--- a/contracts/test/LibPricesMock.sol
+++ b/contracts/test/LibPricesMock.sol
@@ -4,19 +4,19 @@ pragma solidity ^0.8.0;
 import "../lib/LibPrices.sol";
 
 contract LibPricesMock {
-    function fairPrice(uint256 oraclePrice, int256 _timeValue) public pure returns (uint256) {
+    function fairPrice(uint256 oraclePrice, int256 _timeValue) external pure returns (uint256) {
         return Prices.fairPrice(oraclePrice, _timeValue);
     }
 
-    function timeValue(uint256 averageTracerPrice, uint256 averageOraclePrice) public pure returns (int256) {
+    function timeValue(uint256 averageTracerPrice, uint256 averageOraclePrice) external pure returns (int256) {
         return Prices.timeValue(averageTracerPrice, averageOraclePrice);
     }
 
-    function averagePrice(Prices.PriceInstant memory price) public pure returns (uint256) {
+    function averagePrice(Prices.PriceInstant memory price) external pure returns (uint256) {
         return Prices.averagePrice(price);
     }
 
-    function averagePriceForPeriod(Prices.PriceInstant[24] memory prices) public pure returns (uint256) {
+    function averagePriceForPeriod(Prices.PriceInstant[24] memory prices) external pure returns (uint256) {
         return Prices.averagePriceForPeriod(prices);
     }
 
@@ -24,7 +24,7 @@ contract LibPricesMock {
         uint256 _globalLeverage,
         uint256 oldLeverage,
         uint256 newLeverage
-    ) public pure returns (uint256) {
+    ) external pure returns (uint256) {
         return Prices.globalLeverage(_globalLeverage, oldLeverage, newLeverage);
     }
 
@@ -32,7 +32,7 @@ contract LibPricesMock {
         uint256 hour,
         Prices.PriceInstant[24] memory tracerPrices,
         Prices.PriceInstant[24] memory oraclePrices
-    ) public pure returns (Prices.TWAP memory) {
+    ) external pure returns (Prices.TWAP memory) {
         return Prices.calculateTWAP(hour, tracerPrices, oraclePrices);
     }
 }

--- a/contracts/test/TraderMock.sol
+++ b/contracts/test/TraderMock.sol
@@ -174,7 +174,7 @@ contract TraderMock is ITrader {
      * @return An order that has been previously created in contract, given a user-supplied order
      * @dev Useful for checking to see if a supplied order has actually been created
      */
-    function getOrder(Perpetuals.Order calldata order) public view override returns (Perpetuals.Order memory) {
+    function getOrder(Perpetuals.Order calldata order) external view override returns (Perpetuals.Order memory) {
         bytes32 orderId = Perpetuals.orderId(order);
         return orders[orderId];
     }


### PR DESCRIPTION
# Motivation
Address https://github.com/code-423n4/2021-06-tracer-findings/issues/62
Note that only setMaxSlippage was changed. Other functions outlined cannot be set to external as they override public functions from OpenZeppelin.

Additional functions set to external after analysis with Slither

# Changes
- Updated setMaxSlippage
- Updated functions as per Slither analysis