### PR TITLE
Remove less than redundant check

### DIFF
--- a/contracts/lib/LibLiquidation.sol
+++ b/contracts/lib/LibLiquidation.sol
@@ -134,7 +134,7 @@ library LibLiquidation {
             } else if (avgPrice > receipt.price && receipt.liquidationSide == Perpetuals.Side.Short) {
                 amountToReturn = amountSoldFor - amountExpectedFor;
             }
-            if (amountToReturn <= 0) {
+            if (amountToReturn == 0) {
                 return 0;
             }
 


### PR DESCRIPTION
# Motivation
https://github.com/code-423n4/2021-06-tracer-findings/issues/17

# Changes
- Change `if (amountToReturn <= 0)` to `if (amountToReturn == 0)`. `amoutToReturn` is a uint256 and will never be less than 0.