### PR TITLE
fix: WAD error in withdrawFees and dust removal

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -231,7 +231,7 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
         _updateAccountLeverage(msg.sender);
 
         // Safemath will throw if tvl < amount
-        tvl = tvl - amount;
+        tvl = tvl - uint256(convertedWadAmount);
 
         // perform transfer
         require(IERC20(tracerQuoteToken).transfer(msg.sender, rawTokenAmount), "TCR: Transfer failed");

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -164,7 +164,8 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
 
     /**
      * @notice Allows a user to deposit into their margin account
-     * @dev this contract must be an approved spender of the markets quote token on behalf of the depositer.
+     * @dev This contract must be an approved spender of the markets quote token on behalf of the depositer.
+     * @dev Emits the amount successfully deposited into the account in WAD format with dust removed
      * @param amount The amount of quote tokens to be deposited into the Tracer Market account. This amount
      * should be given in WAD format.
      */
@@ -192,12 +193,13 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
 
         // update market TVL
         tvl = tvl + uint256(convertedWadAmount);
-        emit Deposit(msg.sender, amount);
+        emit Deposit(msg.sender, uint256(convertedWadAmount));
     }
 
     /**
      * @notice Allows a user to withdraw from their margin account
      * @dev Ensures that the users margin percent is valid after withdraw
+     * @dev Emits the amount successfully withdrawn in WAD format without dust
      * @param amount The amount of margin tokens to be withdrawn from the tracer market account. This amount
      * should be given in WAD format
      */

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -548,6 +548,7 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
      *      Fees is also subtracted from the total value locked in the market because
      *      fees are taken out of trades that result in users' quotes being modified, and
      *      don't otherwise get subtracted from the tvl of the market
+     * @dev Emits the amount of quote tokens successfully transferred to the owner
      */
     function withdrawFees() external override {
         require(fees != 0, "TCR: no fees");

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -555,9 +555,12 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
         fees = 0;
         tvl = tvl - tempFees;
 
+        // Convert fees from WAD format to token representation
+        uint256 rawTokenFees = Balances.wadToToken(quoteTokenDecimals, tempFees);
+
         // Withdraw from the account
-        require(IERC20(tracerQuoteToken).transfer(feeReceiver, tempFees), "TCR: Transfer failed");
-        emit FeeWithdrawn(feeReceiver, tempFees);
+        require(IERC20(tracerQuoteToken).transfer(feeReceiver, rawTokenFees), "TCR: Transfer failed");
+        emit FeeWithdrawn(feeReceiver, rawTokenFees);
     }
 
     function getBalance(address account) external view override returns (Balances.Account memory) {

--- a/deploy/FullDeployTest.js
+++ b/deploy/FullDeployTest.js
@@ -102,9 +102,9 @@ module.exports = async function (hre) {
         contract: "GasOracle",
     })
 
-    // deploy token with an initial supply of 100000
+    // deploy token with an initial supply of 100000 and 8 decimals
     const token = await deploy("QuoteToken", {
-        args: [ethers.utils.parseEther("10000000"), "Test Token", "TST", 18], //10 mil supply
+        args: [ethers.utils.parseEther("10000000"), "Test Token", "TST", 8], //10 mil supply
         from: deployer,
         log: true,
         contract: "TestToken",
@@ -192,7 +192,7 @@ module.exports = async function (hre) {
     })
 
     let maxLeverage = ethers.utils.parseEther("12.5")
-    let tokenDecimals = new ethers.BigNumber.from("18").toString()
+    let tokenDecimals = new ethers.BigNumber.from("8").toString()
     let feeRate = 0 // 0 percent
     let fundingRateSensitivity = ethers.utils.parseEther("1")
     let maxLiquidationSlippage = ethers.utils.parseEther("0.5") // 50 percent

--- a/test/unit/TracerPerpetualSwaps.js
+++ b/test/unit/TracerPerpetualSwaps.js
@@ -212,10 +212,13 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                 expect(difference).to.equal("100000000")
 
                 // default token only uses 8 decimals, so the last bit should be ignored in contract balance
+                let expected = ethers.utils.parseEther("4.000000000")
                 let balance = await tracer.balances(deployer)
-                await expect(balance.position.quote).to.equal(
-                    ethers.utils.parseEther("4.000000000")
-                )
+                await expect(balance.position.quote).to.equal(expected)
+
+                // check TVL has been updated without dust
+                let tvl = await tracer.tvl()
+                await expect(tvl).to.be.equal(expected)
             })
         })
     })

--- a/test/unit/TracerPerpetualSwaps.js
+++ b/test/unit/TracerPerpetualSwaps.js
@@ -105,6 +105,17 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                 let tvl = await tracer.tvl()
                 expect(tvl).to.equal(ethers.utils.parseEther("5"))
             })
+
+            it("emits an event", async () => {
+                await quoteToken.approve(
+                    tracer.address,
+                    ethers.utils.parseEther("5")
+                )
+
+                await expect(tracer.deposit(ethers.utils.parseEther("5")))
+                    .to.emit(tracer, "Deposit")
+                    .withArgs(accounts[0].address, "5000000000000000000")
+            })
         })
 
         context("when the user has not set allowance", async () => {
@@ -174,6 +185,12 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
             it("updates the total TVL", async () => {
                 let tvl = await tracer.tvl()
                 expect(tvl).to.equal(ethers.utils.parseEther("4"))
+            })
+
+            it("emits an event", async () => {
+                await expect(tracer.withdraw(ethers.utils.parseEther("1")))
+                    .to.emit(tracer, "Withdraw")
+                    .withArgs(accounts[0].address, "1000000000000000000")
             })
         })
 

--- a/test/unit/TracerPerpetualSwaps.js
+++ b/test/unit/TracerPerpetualSwaps.js
@@ -773,10 +773,8 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                 let balanceBefore = await quoteToken.balanceOf(feeReceiver)
                 await tracer.connect(accounts[0]).withdrawFees()
                 let balanceAfter = await quoteToken.balanceOf(feeReceiver)
-                // 2 quote tokens received as fees (1% of 100 * 2)
-                expect(balanceAfter.sub(balanceBefore)).to.equal(
-                    ethers.utils.parseEther("2")
-                )
+                // 2 quote tokens (8 decimals) received as fees (1% of 100 * 2)
+                expect(balanceAfter.sub(balanceBefore)).to.equal("200000000")
             })
 
             it("resets fees to 0", async () => {
@@ -784,6 +782,7 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                 await tracer.connect(accounts[0]).withdrawFees()
                 let feesAfter = await tracer.fees()
                 expect(feesAfter).to.equal(0)
+                // fees are represented in WAD format by the contract
                 expect(feesBefore.sub(feesAfter)).to.equal(
                     ethers.utils.parseEther("2")
                 )
@@ -793,7 +792,7 @@ describe("Unit tests: TracerPerpetualSwaps.sol", function () {
                 let feeReceiver = await tracer.feeReceiver()
                 await expect(tracer.withdrawFees())
                     .to.emit(tracer, "FeeWithdrawn")
-                    .withArgs(feeReceiver, ethers.utils.parseEther("2"))
+                    .withArgs(feeReceiver, "200000000")
             })
 
             it("subtracts fees from the tvl of the market", async () => {


### PR DESCRIPTION
# Motivation
The test token used has 18 decimals, makes it impossible to test WAD conversions and dust removal mechanisms.

The withdrawFees does not convert fees value back to token representation which causes an error when ERC20.transfer is called (i.e more funds are requested than should be since WAD value has been scaled up).

There is inconsistency between the deposit and withdraw functions regarding dust in emitted events and TVL calculations

# Changes
Change the test token to have 8 decimals

In `withdrawFees`, convert `fees` from WAD representation back to token representation to prevent error thrown during transfer call.

`Deposited` event emits the amount deposited with dust, while the `Withdraw` event does not (https://github.com/code-423n4/2021-06-tracer-findings/issues/56)
- Emit the deposited amount with dust removed instead of the raw amount
- Amend Natspec comments to reflect events
- Unit tests

Withdraw TVL calculation updates including dust, whereas deposit does not (https://github.com/code-423n4/2021-06-tracer-findings/issues/57)
- Use value with dust removed for TVL calculation
- Unit test