### PR TITLE
Validate orders in Trader.sol

### DIFF
--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -103,7 +103,7 @@ contract Trader is ITrader {
             // make low level call to catch revert
             // todo this could be succeptible to re-entrancy as
             // market is never verified
-            (bool success, ) = makeOrder.market.call(
+            (bool success, bytes memory data) = makeOrder.market.call(
                 abi.encodePacked(
                     ITracerPerpetualSwaps(makeOrder.market).matchOrders.selector,
                     abi.encode(makeOrder, takeOrder, fillAmount)
@@ -112,6 +112,8 @@ contract Trader is ITrader {
 
             // ignore orders that cannot be executed
             if (!success) continue;
+            bool orderStatus = abi.decode(data, (bool));
+            if (!orderStatus) continue;
 
             uint256 executionPrice = Perpetuals.getExecutionPrice(makeOrder, takeOrder);
             uint256 newMakeAverage = Perpetuals.calculateAverageExecutionPrice(

--- a/contracts/test/TraderMock.sol
+++ b/contracts/test/TraderMock.sol
@@ -113,7 +113,7 @@ contract TraderMock is ITrader {
             // make low level call to catch revert
             // todo this could be succeptible to re-entrancy as
             // market is never verified
-            (bool success, ) = makeOrder.market.call(
+            (bool success, bytes memory data) = makeOrder.market.call(
                 abi.encodePacked(
                     ITracerPerpetualSwaps(makeOrder.market).matchOrders.selector,
                     abi.encode(makeOrder, takeOrder, fillAmount)
@@ -122,6 +122,8 @@ contract TraderMock is ITrader {
 
             // ignore orders that cannot be executed
             if (!success) continue;
+            bool orderStatus = abi.decode(data, (bool));
+            if (!orderStatus) continue;
 
             // update order state
             filled[makerOrderId] = makeOrderFilled + fillAmount;


### PR DESCRIPTION
# Motivation
https://github.com/code-423n4/2021-06-tracer-findings/issues/126

# Changes
- Validate that the matchOrders function returns true before processing a trade in trader.sol