### PR TITLE
Add reentrancy guard to Trader.sol

### DIFF
--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -5,11 +5,12 @@ import "./Interfaces/ITracerPerpetualSwaps.sol";
 import "./Interfaces/Types.sol";
 import "./Interfaces/ITrader.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 /**
  * The Trader contract is used to validate and execute off chain signed and matched orders
  */
-contract Trader is ITrader {
+contract Trader is ITrader, ReentrancyGuard {
     // EIP712 Constants
     // https://eips.ethereum.org/EIPS/eip-712
     string private constant EIP712_DOMAIN_NAME = "Tracer Protocol";
@@ -65,6 +66,7 @@ contract Trader is ITrader {
     function executeTrade(Types.SignedLimitOrder[] memory makers, Types.SignedLimitOrder[] memory takers)
         external
         override
+        nonReentrant
     {
         require(makers.length == takers.length, "TDR: Lengths differ");
 

--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -103,8 +103,6 @@ contract Trader is ITrader, ReentrancyGuard {
             // match orders
             // referencing makeOrder.market is safe due to above require
             // make low level call to catch revert
-            // todo this could be succeptible to re-entrancy as
-            // market is never verified
             (bool success, ) = makeOrder.market.call(
                 abi.encodePacked(
                     ITracerPerpetualSwaps(makeOrder.market).matchOrders.selector,


### PR DESCRIPTION
# Motivation
Prevent reentrancy in the `executeTrade` function in `Trader.sol`. Reentrancy is possible as it makes a call to the order market without verifying that it is a legitimate Tracer contract (https://github.com/code-423n4/2021-06-tracer-findings/issues/72).

# Changes
- Use OpenZeppelin's ReentrancyGuard on the `executeTrade` function