### PR TITLE
Use calldata instead of memory in function parameter declarations

### DIFF
--- a/contracts/Liquidation.sol
+++ b/contracts/Liquidation.sol
@@ -273,7 +273,7 @@ contract Liquidation is ILiquidation, Ownable {
      * @param receiptId the id of the liquidation receipt the orders are being claimed against
      */
     function calcUnitsSold(
-        Perpetuals.Order[] memory orders,
+        Perpetuals.Order[] calldata orders,
         address traderContract,
         uint256 receiptId
     ) public override returns (uint256, uint256) {
@@ -329,7 +329,7 @@ contract Liquidation is ILiquidation, Ownable {
      */
     function calcAmountToReturn(
         uint256 escrowId,
-        Perpetuals.Order[] memory orders,
+        Perpetuals.Order[] calldata orders,
         address traderContract
     ) public override returns (uint256) {
         LibLiquidation.LiquidationReceipt memory receipt = liquidationReceipts[escrowId];
@@ -395,7 +395,7 @@ contract Liquidation is ILiquidation, Ownable {
      */
     function claimReceipt(
         uint256 receiptId,
-        Perpetuals.Order[] memory orders,
+        Perpetuals.Order[] calldata orders,
         address traderContract
     ) external override {
         // Claim the receipts from the escrow system, get back amount to return

--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -246,8 +246,8 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
      * @return Whether the two orders were able to be matched successfully
      */
     function matchOrders(
-        Perpetuals.Order memory order1,
-        Perpetuals.Order memory order2,
+        Perpetuals.Order calldata order1,
+        Perpetuals.Order calldata order2,
         uint256 fillAmount
     ) external override onlyWhitelisted returns (bool) {
         require(order1.market == address(this), "TCR: Wrong market");
@@ -335,8 +335,8 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
      * @return The new balances of the two accounts after the trade
      */
     function _executeTrade(
-        Perpetuals.Order memory order1,
-        Perpetuals.Order memory order2,
+        Perpetuals.Order calldata order1,
+        Perpetuals.Order calldata order2,
         uint256 fillAmount,
         uint256 executionPrice
     ) internal view returns (Balances.Position memory, Balances.Position memory) {

--- a/contracts/Trader.sol
+++ b/contracts/Trader.sol
@@ -49,11 +49,11 @@ contract Trader is ITrader, ReentrancyGuard {
         );
     }
 
-    function filledAmount(Perpetuals.Order memory order) external view override returns (uint256) {
+    function filledAmount(Perpetuals.Order calldata order) external view override returns (uint256) {
         return filled[Perpetuals.orderId(order)];
     }
 
-    function getAverageExecutionPrice(Perpetuals.Order memory order) external view override returns (uint256) {
+    function getAverageExecutionPrice(Perpetuals.Order calldata order) external view override returns (uint256) {
         return averageExecutionPrice[Perpetuals.orderId(order)];
     }
 
@@ -63,7 +63,7 @@ contract Trader is ITrader, ReentrancyGuard {
      * @param makers An array of signed make orders
      * @param takers An array of signed take orders
      */
-    function executeTrade(Types.SignedLimitOrder[] memory makers, Types.SignedLimitOrder[] memory takers)
+    function executeTrade(Types.SignedLimitOrder[] calldata makers, Types.SignedLimitOrder[] calldata takers)
         external
         override
         nonReentrant
@@ -143,7 +143,7 @@ contract Trader is ITrader, ReentrancyGuard {
      * @dev Should only be called with a verified signedOrder and with index
      *      < signedOrders.length
      */
-    function grabOrder(Types.SignedLimitOrder[] memory signedOrders, uint256 index)
+    function grabOrder(Types.SignedLimitOrder[] calldata signedOrders, uint256 index)
         internal
         returns (Perpetuals.Order memory)
     {
@@ -166,7 +166,7 @@ contract Trader is ITrader, ReentrancyGuard {
      * @param order the limit order being hashed
      * @return an EIP712 compliant hash (with headers) of the limit order
      */
-    function hashOrder(Perpetuals.Order memory order) public view override returns (bytes32) {
+    function hashOrder(Perpetuals.Order calldata order) public view override returns (bytes32) {
         return
             keccak256(
                 abi.encodePacked(
@@ -202,7 +202,7 @@ contract Trader is ITrader, ReentrancyGuard {
      * @return if signedOrder1 is compatible with signedOrder2
      * @dev does not throw if pairs are invalid
      */
-    function isValidPair(Types.SignedLimitOrder memory signedOrder1, Types.SignedLimitOrder memory signedOrder2)
+    function isValidPair(Types.SignedLimitOrder calldata signedOrder1, Types.SignedLimitOrder calldata signedOrder2)
         internal
         pure
         returns (bool)
@@ -210,11 +210,10 @@ contract Trader is ITrader, ReentrancyGuard {
         return (signedOrder1.order.market == signedOrder2.order.market);
     }
 
-    function areValidAddresses(Types.SignedLimitOrder memory signedOrder1, Types.SignedLimitOrder memory signedOrder2)
-        internal
-        pure
-        returns (bool)
-    {
+    function areValidAddresses(
+        Types.SignedLimitOrder calldata signedOrder1,
+        Types.SignedLimitOrder calldata signedOrder2
+    ) internal pure returns (bool) {
         bool order1Market = signedOrder1.order.market != address(0);
         bool order2Market = signedOrder2.order.market != address(0);
         bool order1Maker = signedOrder1.order.maker != address(0);
@@ -228,7 +227,7 @@ contract Trader is ITrader, ReentrancyGuard {
      * @param signedOrder The unsigned order to verify the signature of
      * @return true is signer has signed the order, else false
      */
-    function verifySignature(address signer, Types.SignedLimitOrder memory signedOrder)
+    function verifySignature(address signer, Types.SignedLimitOrder calldata signedOrder)
         public
         view
         override


### PR DESCRIPTION
# Motivation
Address https://github.com/code-423n4/2021-06-tracer-findings/issues/36

# Changes 
- Use `calldata` where appropriate. I.e in functions where the parameters are read from but never modified.