### PR TITLE
Resolve todos

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -257,7 +257,6 @@ contract Pricing is IPricing {
         );
     }
 
-    // todo by using public variables lots of these can be removed
     /**
      * @return each variable of the fundingRate struct of a particular tracer at a particular funding rate index
      */

--- a/contracts/lib/LibLiquidation.sol
+++ b/contracts/lib/LibLiquidation.sol
@@ -85,7 +85,6 @@ library LibLiquidation {
             PRBMathSD59x18.div(amount, PRBMathSD59x18.abs(liquidatedBase))
         );
 
-        // todo with the below * -1, note ints can overflow as 2^-127 is valid but 2^127 is not.
         if (liquidatedBase < 0) {
             _liquidatorBaseChange = amount * (-1);
             _liquidateeBaseChange = amount;


### PR DESCRIPTION
# Motivation
Todos need to be resolved in code base

# Changes
`LibLiquidation.sol` "// todo with the below * -1, note ints can overflow as 2^-127 is valid but 2^127 is not."
- Remove comment, no changes made.
- As of solidity 0.8.0, [arithmetic operations will revert on overflow](https://docs.soliditylang.org/en/v0.8.0/080-breaking-changes.html). Therefore, no special case is required to revert when int256.MIN * -1 occurs (unless a custom revert message is needed).

`Pricing.sol`  "// todo by using public variables lots of these can be removed"
- Remove comment, no changes made.
- Getters appear to be appropriate. In the case of `getFundingRate` and `getInsuranceFundingRate`, a getter is required to implicitly convert the return type of each mapping to Prices.FundingRateInstant memory so that it can be used in the interface.

Resolved re-entrancy issue in mock trader and removed comment.