### PR TITLE
Use correct token format in drain pool and refactor

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -178,7 +178,7 @@ contract Insurance is IInsurance {
 
         uint256 rawTokenAmount = Balances.wadToToken(collateralAssetDecimals, amount);
         tracerMarginToken.approve(address(tracer), rawTokenAmount);
-        tracer.deposit(rawTokenAmount);
+        tracer.deposit(amount);
     }
 
     /**


### PR DESCRIPTION
# Motivation
Address https://github.com/code-423n4/2021-06-tracer-findings/issues/99

# Changes
- Convert back to raw token value before calling aprove
- Refactor so that quote token address and decimals are saved as state variables