### PR TITLE
Fix hour tracking in Pricing

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -71,41 +71,41 @@ contract Pricing is IPricing {
     /**
      * @notice Updates pricing information given a trade of a certain volume at
      *         a set price
-     * @param tradePrice the price the trade executed at
-     * @param fillAmount the amount the trade was filled for
+     * @param tradePrice The price the trade executed at
+     * @param fillAmount The amount the trade was filled for
      */
     function recordTrade(uint256 tradePrice, uint256 fillAmount) external override onlyTracer {
         uint256 currentOraclePrice = oracle.latestAnswer();
-        // update pricing information if a trade has not been recorded in the last hour
+        // Update pricing information if a trade has not been recorded in the last hour
         if (startLastHour <= block.timestamp - 1 hours) {
-            // get the last recorded hourly price, returns max integer if no trades occurred
+            // Get the last recorded hourly price, returns max integer if no trades occurred
             uint256 hourlyTracerPrice = getHourlyAvgTracerPrice(currentHour);
 
-            // emit the hourly average and udpate funding rate if trades occurred
+            // Emit the hourly average and udpate funding rate if trades occurred
             if (hourlyTracerPrice != type(uint256).max) {
-                // emit the old hourly average
+                // Emit the old hourly average
                 emit HourlyPriceUpdated(hourlyTracerPrice, currentHour);
 
-                // update funding rate for the previous hour
+                // Update funding rate for the previous hour
                 updateFundingRate();
             }
 
             uint256 elapsedHours = (block.timestamp - startLastHour) / 3600;
 
-            // update the current hour and enter the new price
+            // Update the current hour and enter the new price
             currentHour = uint8((uint256(currentHour) + elapsedHours) % 24);
             createPriceEntry(tradePrice, currentOraclePrice, fillAmount, currentHour);
 
-            // if more than one hour passed, update any skipped hour prices as 0 to remove stale entries
+            // If more than one hour passed, update any skipped hour prices as 0 to remove stale entries
             if (elapsedHours > 1) {
-                // calculate the number of hours to overwrite
-                // cap elapsed hours to 24 hours to limit for loop iterations
-                // subtract 1 since the last elapsed hour is the recorded trade with data
+                // Calculate the number of hours to overwrite
+                // Cap elapsed hours to 24 hours to limit for loop iterations
+                // Subtract 1 since the last elapsed hour is the recorded trade with data
                 uint8 skippedHours = uint8(elapsedHours > 24 ? 24 : elapsedHours) - 1;
 
                 uint8 staleHour = currentHour;
                 for (uint256 i = 0; i < skippedHours; i++) {
-                    // decrement stale hour backwards from current time to update skipped entries
+                    // Decrement stale hour backwards from current time to update skipped entries
                     if (staleHour > 0) {
                         staleHour--;
                     } else {
@@ -115,10 +115,10 @@ contract Pricing is IPricing {
                 }
             }
 
-            // update time of last hourly recording
+            // Update time of last hourly recording
             startLastHour += (elapsedHours * 3600);
 
-            // update the time value
+            // Update the time value
             if (startLast24Hours <= block.timestamp - 24 hours) {
                 // Update the interest rate every 24 hours
                 updateTimeValue();
@@ -135,7 +135,7 @@ contract Pricing is IPricing {
      * @param marketPrice The price that a tracer was bought at, returned by the TracerPerpetualSwaps.sol contract when an order is filled
      * @param oraclePrice The price of the underlying asset that the Tracer is based upon as returned by a Chainlink Oracle
      * @param fillAmount The amount of the order that was filled at some price
-     * @param hour the hour to overwrite in the hourly Oracle and Tracer price arrays
+     * @param hour The hour to overwrite in the hourly Oracle and Tracer price arrays
      */
     function createPriceEntry(
         uint256 marketPrice,
@@ -143,7 +143,7 @@ contract Pricing is IPricing {
         uint256 fillAmount,
         uint8 hour
     ) internal {
-        // Make new hourly record, total = marketprice, numTrades set to the amount filled;
+        // Make new hourly record, total = marketPrice, numTrades set to the amount filled;
         Prices.PriceInstant memory newHourly = Prices.PriceInstant(
             PRBMathUD60x18.mul(marketPrice, fillAmount),
             fillAmount
@@ -158,7 +158,7 @@ contract Pricing is IPricing {
     }
 
     /**
-     * @notice cumulatively adds a new Tracer and asset price to the existing prices recorded at the current hour
+     * @notice Cumulatively adds a new Tracer and asset price to the existing prices recorded at the current hour
      * @param marketPrice The price that a tracer was bought at, returned by the TracerPerpetualSwaps.sol contract when an order is filled
      * @param oraclePrice The price of the underlying asset that the Tracer is based upon as returned by a Chainlink Oracle
      * @param fillAmount The amount of the order that was filled at some price
@@ -168,7 +168,7 @@ contract Pricing is IPricing {
         uint256 oraclePrice,
         uint256 fillAmount
     ) internal {
-        // add the total market price of the trade to a running total
+        // Add the total market price of the trade to a running total
         // and increment number of fill amounts
         hourlyTracerPrices[currentHour].cumulativePrice =
             hourlyTracerPrices[currentHour].cumulativePrice +

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -76,7 +76,7 @@ contract Pricing is IPricing {
      */
     function recordTrade(uint256 tradePrice, uint256 fillAmount) external override onlyTracer {
         uint256 currentOraclePrice = oracle.latestAnswer();
-        // update rates if a trade has not been recorded in the last hour
+        // update pricing information if a trade has not been recorded in the last hour
         if (startLastHour <= block.timestamp - 1 hours) {
             // get the last recorded hourly price, returns max integer if no trades occurred
             uint256 hourlyTracerPrice = getHourlyAvgTracerPrice(currentHour);
@@ -116,7 +116,7 @@ contract Pricing is IPricing {
             }
 
             // update time of last hourly recording
-            startLastHour = block.timestamp;
+            startLastHour += (elapsedHours * 3600);
 
             // update the time value
             if (startLast24Hours <= block.timestamp - 24 hours) {

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -93,7 +93,7 @@ contract Pricing is IPricing {
             uint256 elapsedHours = (block.timestamp - startLastHour) / 3600;
 
             // update the current hour and enter the new price
-            currentHour = (currentHour + uint8(elapsedHours)) % 24;
+            currentHour = uint8((uint256(currentHour) + elapsedHours) % 24);
             createPriceEntry(tradePrice, currentOraclePrice, fillAmount, currentHour);
 
             // if more than one hour passed, update any skipped hour prices as 0 to remove stale entries

--- a/test/functional/TracerPerpetualSwaps.js
+++ b/test/functional/TracerPerpetualSwaps.js
@@ -433,7 +433,8 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                 expect(fundingIndex).to.equal(0)
 
                 // time travel forward 26 hours to check pricing state after no trades occurred
-                await forwardTime(26 * 60 * 60 + 100)
+                let passedHours = 26
+                await forwardTime(passedHours * 60 * 60 + 100)
 
                 // STATE 2:
                 // hour = (2 + 26) % 24 = 4
@@ -445,7 +446,7 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                     "1000000000000000000"
                 )
 
-                // make trade in new hour to tick over funding index
+                // execute new trade with price of 1.25
                 await traderInstance.executeTrade(
                     [mockSignedOrder4],
                     [mockSignedOrder5]
@@ -453,9 +454,9 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                 await traderInstance.clearFilled(mockSignedOrder4)
                 await traderInstance.clearFilled(mockSignedOrder5)
 
-                // check pricing is in hour 4
+                let expectedHour = (2 + passedHours) % 24
                 currentHour = await pricing.currentHour()
-                expect(currentHour).to.equal(4)
+                expect(currentHour).to.equal(expectedHour)
 
                 // check the average price has not included last price recording which is stale
                 // new average should just be price of new trade, 1.25
@@ -464,7 +465,6 @@ describe("Functional tests: TracerPerpetualSwaps.sol", function () {
                     "1250000000000000000"
                 )
 
-                // check funding index is 1
                 fundingIndex = await pricing.currentFundingIndex()
                 expect(fundingIndex).to.equal(1)
             })


### PR DESCRIPTION
# Motivation
24 hour periods can go out of sync since `startLastHour`, used to determine if an hour elapsed was being updated to the current time whenever a new price was recorded.

For example:
Price recorded at hour 0, then 1.5 hours passes with no trades. New trade occurs so new price recorded, `startLastHour` is set to hour 1.5, but hour array is still at hour 1. Thus, the hourly recordings are now 0.5 hours out of sync. Can continue until the hours are significantly out of sync with 24 hours if there is very low trade volume.

Current hour increment also had the risk of integer overflow when elapsed hours exceeded 256 hours.

# Changes
- Correctly update `startLastHour` so that each 24 hour period is strictly 24 hours
- Refactor the updatePricing function
- Cast current hour to uint256 to prevent overflow