### PR TITLE
Added failure reason in failed order event

### DIFF
--- a/contracts/TracerPerpetualSwaps.sol
+++ b/contracts/TracerPerpetualSwaps.sol
@@ -349,6 +349,11 @@ contract TracerPerpetualSwaps is ITracerPerpetualSwaps, Ownable {
         return (newPos1, newPos2);
     }
 
+    /**
+     * @notice given the positions of two traders, determine if they have sufficient margin.
+     * @return return Perpetuals.OrderMatchingResult.VALID if both positions are valid.
+     *         return Perpetuals.OrderMatchingResult.SHORT_MARGIN or LONG_MARGIN if one of the trader positions is invalid.
+     */
     function _validateMargins(
         Balances.Position memory newPositionLong,
         address longMaker,

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -119,37 +119,6 @@ library Perpetuals {
     }
 
     /**
-     * @notice Checks if two orders can be matched given their price, side of trade
-     *  (two longs can't can't trade with one another, etc.), expiry times, fill amounts,
-     *  markets being the same, makers being different, and time validation.
-     * @param a The first order
-     * @param aFilled Amount of the first order that has already been filled
-     * @param b The second order
-     * @param bFilled Amount of the second order that has already been filled
-     */
-    function canMatch(
-        Order memory a,
-        uint256 aFilled,
-        Order memory b,
-        uint256 bFilled
-    ) internal view returns (bool) {
-        uint256 currentTime = block.timestamp;
-
-        /* predicates */
-        bool opposingSides = a.side != b.side;
-        // long order must have a price >= short order
-        bool pricesMatch = a.side == Side.Long ? a.price >= b.price : a.price <= b.price;
-        bool marketsMatch = a.market == b.market;
-        bool makersDifferent = a.maker != b.maker;
-        bool notExpired = currentTime < a.expires && currentTime < b.expires;
-        bool notFilled = aFilled < a.amount && bFilled < b.amount;
-        bool createdBefore = currentTime >= a.created && currentTime >= b.created;
-
-        return
-            pricesMatch && makersDifferent && marketsMatch && opposingSides && notExpired && notFilled && createdBefore;
-    }
-
-    /**
      * @notice Gets the execution price of two orders, given their creation times
      * @param a The first order
      * @param b The second order

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -142,9 +142,9 @@ library Perpetuals {
      * @return OrderMatchingResult indicating if the two orders can be matched, or the reason if they can't
      */
     function canMatch(
-        Perpetuals.Order calldata long,
+        Order calldata long,
         uint256 longFilled,
-        Perpetuals.Order calldata short,
+        Order calldata short,
         uint256 shortFilled
     ) internal view returns (OrderMatchingResult) {
         uint256 currentTime = block.timestamp;

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -132,21 +132,6 @@ library Perpetuals {
     }
 
     /**
-     * @notice Gets the execution price of two orders, given their creation times
-     * @param a The first order
-     * @param b The second order
-     * @return Price that the orders will be executed at
-     */
-    function getExecutionPrice(Order memory a, Order memory b) internal pure returns (uint256) {
-        bool aIsFirst = a.created <= b.created;
-        if (aIsFirst) {
-            return a.price;
-        } else {
-            return b.price;
-        }
-    }
-
-    /**
      * @notice Checks if two orders can be matched given their price, side of trade
      *  (two longs can't can't trade with one another, etc.), expiry times, fill amounts,
      *  markets being the same, makers being different, and time validation.
@@ -182,6 +167,21 @@ library Perpetuals {
             return OrderMatchingResult.INVALID_TIME;
         } else {
             return OrderMatchingResult.VALID;
+        }
+    }
+
+    /**
+     * @notice Gets the execution price of two orders, given their creation times
+     * @param a The first order
+     * @param b The second order
+     * @return Price that the orders will be executed at
+     */
+    function getExecutionPrice(Order memory a, Order memory b) internal pure returns (uint256) {
+        bool aIsFirst = a.created <= b.created;
+        if (aIsFirst) {
+            return a.price;
+        } else {
+            return b.price;
         }
     }
 }

--- a/contracts/lib/LibPerpetuals.sol
+++ b/contracts/lib/LibPerpetuals.sol
@@ -154,6 +154,7 @@ library Perpetuals {
      * @param longFilled Amount of the first order that has already been filled
      * @param short The short side order
      * @param shortFilled Amount of the second order that has already been filled
+     * @return OrderMatchingResult indicating if the two orders can be matched, or the reason if they can't
      */
     function canMatch(
         Perpetuals.Order calldata long,

--- a/contracts/test/LibPerpetualsMock.sol
+++ b/contracts/test/LibPerpetualsMock.sol
@@ -36,13 +36,4 @@ contract PerpetualsMock {
                 insurancePoolSwitchStage
             );
     }
-
-    function canMatch(
-        Perpetuals.Order calldata a,
-        uint256 aFilled,
-        Perpetuals.Order calldata b,
-        uint256 bFilled
-    ) external view returns (bool) {
-        return Perpetuals.canMatch(a, aFilled, b, bFilled);
-    }
 }

--- a/contracts/test/LibPerpetualsMock.sol
+++ b/contracts/test/LibPerpetualsMock.sol
@@ -36,4 +36,13 @@ contract PerpetualsMock {
                 insurancePoolSwitchStage
             );
     }
+
+    function canMatch(
+        Perpetuals.Order calldata a,
+        uint256 aFilled,
+        Perpetuals.Order calldata b,
+        uint256 bFilled
+    ) external view returns (Perpetuals.OrderMatchingResult) {
+        return Perpetuals.canMatch(a, aFilled, b, bFilled);
+    }
 }

--- a/test/unit/LibPerpetuals.js
+++ b/test/unit/LibPerpetuals.js
@@ -375,7 +375,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
 
     describe("canMatch", async () => {
         context("when called with different order prices", async () => {
-            it("returns true if prices do cross", async () => {
+            it("returns VALID if prices do cross", async () => {
                 let priceA = ethers.utils.parseEther("1") // short order
                 let priceB = ethers.utils.parseEther("2") // long order
                 let amount = ethers.utils.parseEther("1")
@@ -383,7 +383,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let sideB = 0
                 let expires = 3021382897 // large unix timestamp
                 let created = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     priceA,
@@ -392,7 +392,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     priceB,
@@ -401,11 +401,17 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let result = await libPerpetuals.canMatch(orderA, 0, orderB, 0)
-                expect(result).to.equal(true)
+                let result = await libPerpetuals.canMatch(
+                    orderLong,
+                    0,
+                    orderShort,
+                    0
+                )
+                // OrderMatchingResult.VALID => 0
+                expect(result).to.equal(0)
             })
 
-            it("returns false if prices don't cross", async () => {
+            it("returns PRICE_MISMATCH if prices don't cross", async () => {
                 let priceA = ethers.utils.parseEther("2") // short order
                 let priceB = ethers.utils.parseEther("1") // long order
                 let amount = ethers.utils.parseEther("1")
@@ -413,7 +419,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let sideB = 0
                 let expires = 3021382897 // large unix timestamp
                 let created = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     priceA,
@@ -422,7 +428,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     priceB,
@@ -431,20 +437,26 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let result = await libPerpetuals.canMatch(orderA, 0, orderB, 0)
-                expect(result).to.equal(false)
+                let result = await libPerpetuals.canMatch(
+                    orderLong,
+                    0,
+                    orderShort,
+                    0
+                )
+                // OrderMatchingResult.PRICE_MISMATCH => 3
+                expect(result).to.equal(3)
             })
         })
 
         context("when called with the same side", async () => {
-            it("returns false", async () => {
+            it("returns SIDE_MISMATCH", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 0
                 let sideB = 0
                 let expires = 3021382897 // large unix timestamp
                 let created = 0
-                let orderA = [
+                let orderLong1 = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -453,7 +465,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong2 = [
                     accounts[2].address,
                     zeroAddress,
                     price,
@@ -462,13 +474,19 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let result = await libPerpetuals.canMatch(orderA, 0, orderB, 0)
-                expect(result).to.equal(false)
+                let result = await libPerpetuals.canMatch(
+                    orderLong1,
+                    0,
+                    orderLong2,
+                    0
+                )
+                // OrderMatchingResult.SIDE_MISMATCH => 2
+                expect(result).to.equal(2)
             })
         })
 
         context("when called with an expired order", async () => {
-            it("returns false if order a is expired", async () => {
+            it("returns EXPIRED if order a is expired", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -476,7 +494,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let expiresA = 500
                 let expiresB = 3021382897 // large unix timestamp
                 let created = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -485,7 +503,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expiresA,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     price,
@@ -494,11 +512,17 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expiresB,
                     created,
                 ]
-                let result = await libPerpetuals.canMatch(orderA, 0, orderB, 0)
-                expect(result).to.equal(false)
+                let result = await libPerpetuals.canMatch(
+                    orderLong,
+                    0,
+                    orderShort,
+                    0
+                )
+                // OrderMatchingResult.EXPIRED => 5
+                expect(result).to.equal(5)
             })
 
-            it("returns false if order b is expired", async () => {
+            it("returns EXPIRED if order b is expired", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -506,7 +530,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let expiresB = 250
                 let expiresA = 3021382897 // large unix timestamp
                 let created = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -515,7 +539,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expiresA,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     price,
@@ -524,11 +548,17 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expiresB,
                     created,
                 ]
-                let result = await libPerpetuals.canMatch(orderA, 0, orderB, 0)
-                expect(result).to.equal(false)
+                let result = await libPerpetuals.canMatch(
+                    orderLong,
+                    0,
+                    orderShort,
+                    0
+                )
+                // OrderMatchingResult.EXPIRED => 5
+                expect(result).to.equal(5)
             })
 
-            it("returns false if both orders are expired", async () => {
+            it("returns EXPIRED if both orders are expired", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -536,7 +566,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let expiresA = 350
                 let expiresB = 750
                 let created = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -545,7 +575,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expiresA,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     price,
@@ -554,13 +584,19 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expiresB,
                     created,
                 ]
-                let result = await libPerpetuals.canMatch(orderA, 0, orderB, 0)
-                expect(result).to.equal(false)
+                let result = await libPerpetuals.canMatch(
+                    orderLong,
+                    0,
+                    orderShort,
+                    0
+                )
+                // OrderMatchingResult.EXPIRED => 5
+                expect(result).to.equal(5)
             })
         })
 
         context("when called with already filled orders", async () => {
-            it("returns false if order a is filled", async () => {
+            it("returns FILLED if order a is filled", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -569,7 +605,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let created = 0
                 let filledA = amount
                 let filledB = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -578,7 +614,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     price,
@@ -588,15 +624,16 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     created,
                 ]
                 let result = await libPerpetuals.canMatch(
-                    orderA,
+                    orderLong,
                     filledA,
-                    orderB,
+                    orderShort,
                     filledB
                 )
-                expect(result).to.equal(false)
+                // OrderMatchingResult.FILLED => 6
+                expect(result).to.equal(6)
             })
 
-            it("returns false if order b is filled", async () => {
+            it("returns FILLED if order b is filled", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -605,7 +642,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let created = 0
                 let filledA = 0
                 let filledB = amount
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -614,7 +651,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     price,
@@ -624,15 +661,16 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     created,
                 ]
                 let result = await libPerpetuals.canMatch(
-                    orderA,
+                    orderLong,
                     filledA,
-                    orderB,
+                    orderShort,
                     filledB
                 )
-                expect(result).to.equal(false)
+                // OrderMatchingResult.FILLED => 6
+                expect(result).to.equal(6)
             })
 
-            it("returns false if both orders are filled", async () => {
+            it("returns FILLED if both orders are filled", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -641,7 +679,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let created = 0
                 let filledA = amount
                 let filledB = amount
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -650,7 +688,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     price,
@@ -660,19 +698,20 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     created,
                 ]
                 let result = await libPerpetuals.canMatch(
-                    orderA,
+                    orderLong,
                     filledA,
-                    orderB,
+                    orderShort,
                     filledB
                 )
-                expect(result).to.equal(false)
+                // OrderMatchingResult.FILLED => 6
+                expect(result).to.equal(6)
             })
         })
 
         context(
             "when called with orders that were created in the future",
             async () => {
-                it("returns false if order a was created in the future", async () => {
+                it("returns INVALID_TIME if order a was created in the future", async () => {
                     let price = ethers.utils.parseEther("1")
                     let amount = ethers.utils.parseEther("1")
                     let sideA = 1
@@ -682,7 +721,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     let createdB = 0
                     let filledA = 0
                     let filledB = 0
-                    let orderA = [
+                    let orderShort = [
                         accounts[1].address,
                         zeroAddress,
                         price,
@@ -691,7 +730,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                         expires,
                         createdA,
                     ]
-                    let orderB = [
+                    let orderLong = [
                         accounts[2].address,
                         zeroAddress,
                         price,
@@ -701,15 +740,16 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                         createdB,
                     ]
                     let result = await libPerpetuals.canMatch(
-                        orderA,
+                        orderLong,
                         filledA,
-                        orderB,
+                        orderShort,
                         filledB
                     )
-                    expect(result).to.equal(false)
+                    // OrderMatchingResult.INVALID_TIME => 7
+                    expect(result).to.equal(7)
                 })
 
-                it("returns false if order b was created in the future", async () => {
+                it("returns INVALID_TIME if order b was created in the future", async () => {
                     let price = ethers.utils.parseEther("1")
                     let amount = ethers.utils.parseEther("1")
                     let sideA = 1
@@ -719,7 +759,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     let createdA = 0
                     let filledA = 0
                     let filledB = 0
-                    let orderA = [
+                    let orderShort = [
                         accounts[1].address,
                         zeroAddress,
                         price,
@@ -728,7 +768,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                         expires,
                         createdA,
                     ]
-                    let orderB = [
+                    let orderLong = [
                         accounts[2].address,
                         zeroAddress,
                         price,
@@ -738,15 +778,16 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                         createdB,
                     ]
                     let result = await libPerpetuals.canMatch(
-                        orderA,
+                        orderLong,
                         filledA,
-                        orderB,
+                        orderShort,
                         filledB
                     )
-                    expect(result).to.equal(false)
+                    // OrderMatchingResult.INVALID_TIME => 7
+                    expect(result).to.equal(7)
                 })
 
-                it("returns false if both orders were created in the future", async () => {
+                it("returns INVALID_TIME if both orders were created in the future", async () => {
                     let price = ethers.utils.parseEther("1")
                     let amount = ethers.utils.parseEther("1")
                     let sideA = 1
@@ -756,7 +797,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     let createdB = 3021382897
                     let filledA = 0
                     let filledB = 0
-                    let orderA = [
+                    let orderShort = [
                         accounts[1].address,
                         zeroAddress,
                         price,
@@ -765,7 +806,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                         expires,
                         createdA,
                     ]
-                    let orderB = [
+                    let orderLong = [
                         accounts[2].address,
                         zeroAddress,
                         price,
@@ -775,18 +816,19 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                         createdB,
                     ]
                     let result = await libPerpetuals.canMatch(
-                        orderA,
+                        orderLong,
                         filledA,
-                        orderB,
+                        orderShort,
                         filledB
                     )
-                    expect(result).to.equal(false)
+                    // OrderMatchingResult.INVALID_TIME => 7
+                    expect(result).to.equal(7)
                 })
             }
         )
 
         context("when called with different markets", async () => {
-            it("returns false", async () => {
+            it("returns MARKET_MISMATCH", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -795,7 +837,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let created = 0
                 let filledA = 0
                 let filledB = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     accounts[3].address,
                     price,
@@ -804,7 +846,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     accounts[4].address,
                     price,
@@ -814,17 +856,18 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     created,
                 ]
                 let result = await libPerpetuals.canMatch(
-                    orderA,
+                    orderLong,
                     filledA,
-                    orderB,
+                    orderShort,
                     filledB
                 )
-                expect(result).to.equal(false)
+                // OrderMatchingResult.MARKET_MISMATCH => 1
+                expect(result).to.equal(1)
             })
         })
 
         context("when called with the same makers", async () => {
-            it("returns false", async () => {
+            it("returns INVALID_TIME", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -833,7 +876,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let created = 0
                 let filledA = 0
                 let filledB = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -842,7 +885,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -852,17 +895,18 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     created,
                 ]
                 let result = await libPerpetuals.canMatch(
-                    orderA,
+                    orderLong,
                     filledA,
-                    orderB,
+                    orderShort,
                     filledB
                 )
-                expect(result).to.equal(false)
+                // OrderMatchingResult.INVALID_TIME => 4
+                expect(result).to.equal(4)
             })
         })
 
         context("when called with valid orders", async () => {
-            it("returns true", async () => {
+            it("returns VALID", async () => {
                 let price = ethers.utils.parseEther("1")
                 let amount = ethers.utils.parseEther("1")
                 let sideA = 1
@@ -871,7 +915,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                 let created = 0
                 let filledA = 0
                 let filledB = 0
-                let orderA = [
+                let orderShort = [
                     accounts[1].address,
                     zeroAddress,
                     price,
@@ -880,7 +924,7 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     expires,
                     created,
                 ]
-                let orderB = [
+                let orderLong = [
                     accounts[2].address,
                     zeroAddress,
                     price,
@@ -890,12 +934,13 @@ describe("Unit tests: LibPerpetuals.sol", function () {
                     created,
                 ]
                 let result = await libPerpetuals.canMatch(
-                    orderA,
+                    orderLong,
                     filledA,
-                    orderB,
+                    orderShort,
                     filledB
                 )
-                expect(result).to.equal(true)
+                // OrderMatchingResult.VALID => 0
+                expect(result).to.equal(0)
             })
         })
     })


### PR DESCRIPTION
# Motivation
When the Tracer contract can't match orders it simply returns a `FailedOrders` event. This event does not provide any reasoning as to why the order fails and makes debugging difficult.

The event was updated to also return an error code stating the reason.

# Changes
- Add `OrderMatchingStatus` enum to list possible order failure reasons
- Make event emit error status depending on reason
- Refactor order validation in `matchOrders` function
- Add unit tests