### PR TITLE
fix: Solidity coverage support

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,7 +5,7 @@ require("hardhat-deploy")
 require("hardhat-abi-exporter")
 require("hardhat-typechain")
 require("@nomiclabs/hardhat-etherscan")
-require("solidity-coverage")
+require("@float-capital/solidity-coverage")
 require("hardhat-gas-reporter")
 
 const mnemonic = ""

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "test": "test"
     },
     "dependencies": {
+        "@float-capital/solidity-coverage": "^0.7.17",
         "@eth-optimism/smock": "0.0.0-20215180366",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@nomiclabs/hardhat-etherscan": "^2.1.2",
@@ -27,7 +28,6 @@
         "prettier": "^2.3.1",
         "prettier-plugin-solidity": "^1.0.0-beta.13",
         "solhint": "^3.3.2",
-        "solidity-coverage": "^0.7.16",
         "truffle-contract-size": "^2.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
# Motivation
Solidity coverage is throwing a stack too deep error on current contracts.
This is an open issue to fix on the main solidity coverage repo. However, there is a fork of solidity coverage which has fixed this issue which can be used in the short-term. https://www.npmjs.com/package/@float-capital/solidity-coverage.

This change will be reverted after issue is resolved on main solidity coverage repo.

# Changes
- use forked version of solidity coverage