### PR TITLE
feat: Pricing test coverage

### DIFF
--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -30,7 +30,7 @@ contract Pricing is IPricing {
 
     // variables used to track time value
     int256 public override timeValue;
-    int256[90] internal dailyDifferences;
+    int256[90] public dailyDifferences;
     uint256 internal lastUpdatedDay;
 
     // the last established funding index
@@ -92,7 +92,8 @@ contract Pricing is IPricing {
             // Get the last recorded hourly price, returns max integer if no trades occurred
             uint256 hourlyTracerPrice = getHourlyAvgTracerPrice(currentHour);
 
-            // Emit the hourly average and udpate funding rate if trades occurred
+            // First time record trade is called, don't update funding rate since no previous trades
+            // hourly tracer price is max integer in this case
             if (hourlyTracerPrice != type(uint256).max) {
                 // Emit the old hourly average
                 emit HourlyPriceUpdated(hourlyTracerPrice, currentHour);
@@ -233,8 +234,8 @@ contract Pricing is IPricing {
      */
     function updateTimeValue(uint256 elapsedDays) internal {
         (uint256 avgPrice, uint256 oracleAvgPrice) = get24HourPrices();
-        // get 24 hours returns max integer if no trades occurred
-        // don't update in this case
+        // first time updateTimeValue is called, don't update time value
+        // there are no previous trades so avg price is max int
         if (avgPrice == type(uint256).max) {
             return;
         }

--- a/contracts/Pricing.sol
+++ b/contracts/Pricing.sol
@@ -30,7 +30,7 @@ contract Pricing is IPricing {
 
     // variables used to track time value
     int256 public override timeValue;
-    int256[90] public dailyDifferences;
+    int256[90] internal dailyDifferences;
     uint256 internal lastUpdatedDay;
 
     // the last established funding index

--- a/test/unit/Pricing.js
+++ b/test/unit/Pricing.js
@@ -274,6 +274,36 @@ describe("Unit tests: Pricing", function () {
             expect(tx).to.equal(expectedTimeValue)
         })
 
+        it("correctly updates when it is called for the first time and more than 24 hours has passed", async () => {
+            const { tracer, trader, pricing, oracle, quoteToken } =
+                await setupTests()
+
+            await depositQuoteTokens(
+                tracer,
+                quoteToken,
+                [long, short],
+                ethers.utils.parseEther("100")
+            )
+
+            // state 1
+            // day: 3
+            // daily average price difference: -2 (10-12)
+            // timeValue: 0
+            await forwardTime(3 * 24 * 3600)
+            await oracle.setPrice(12 * 10 ** 8)
+            await executeTrade(
+                tracer,
+                trader,
+                ethers.utils.parseEther("10"),
+                ethers.utils.parseEther("2"),
+                long.address,
+                short.address
+            )
+            let expectedTimeValue = 0
+            let tx = await pricing.timeValue()
+            expect(tx).to.equal(expectedTimeValue)
+        })
+
         it("returns only the last 90 days of averages", async () => {
             const { tracer, trader, pricing, oracle, quoteToken } =
                 await setupTests()
@@ -333,7 +363,6 @@ describe("Unit tests: Pricing", function () {
                 short.address
             )
             expectedTimeValue = ethers.utils.parseEther("-0.011111111111111111")
-
             tx = await pricing.timeValue()
             expect(tx).to.equal(expectedTimeValue)
         })


### PR DESCRIPTION
# Motivation
Edge case for when recordTrade was called for the first time, and updateTimeValue is called during this call, was not covered (Pricing.sol L#239).
Following this test case, there is full coverage except for a getter function (getHourlyOracleAvgPrice).

# Changes
- Add the test case
- Update some comments