### PR TITLE
feat: Remove functional tests from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,8 @@ jobs:
             - name: Install dependencies
               run: yarn install
 
-            - name: Run unit tests
-              run: yarn run test:unit
-
-            - name: Run functional tests
-              run: yarn run test:functional
+            - name: Run tests
+              run: yarn run test
 
     lint:
         name: Run lints


### PR DESCRIPTION
# Motivation
Removal of functional tests cause CI to fail

# Changes
Change action to `yarn run test` which will run `npx hardhat test`.