### PR TITLE
feat: Global delayed insurance withdrawal

### DIFF
--- a/contracts/Insurance.sol
+++ b/contracts/Insurance.sol
@@ -90,6 +90,10 @@ contract Insurance is IInsurance {
         emit Cooldown(msg.sender, block.timestamp);
     }
 
+    /**
+     * @notice Resets the cooldown period of a user
+     * @dev User must have called intendToWithdraw first
+     */
     function cancelWithdraw() external {
         require(withdrawCooldown[msg.sender] != 0, "INS: Not withdrawing");
         withdrawCooldown[msg.sender] = 0;

--- a/test/unit/InsuranceStaking.js
+++ b/test/unit/InsuranceStaking.js
@@ -86,10 +86,8 @@ describe("Unit tests: Insurance.sol", function () {
     describe("intendToWithdraw", async () => {
         context("when user has zero balance", async () => {
             it("reverts", async () => {
-                await expect(
-                    insurance
-                        .intendToWithdraw()
-                        .to.be.revertedWith("INS: Zero balance")
+                await expect(insurance.intendToWithdraw()).to.be.revertedWith(
+                    "INS: Zero balance"
                 )
             })
         })
@@ -101,8 +99,9 @@ describe("Unit tests: Insurance.sol", function () {
                     quoteToken,
                     ethers.utils.parseEther("1")
                 )
-                await expect(
-                    insurance.intendToWithdraw().to.emit(insurance, "Cooldown")
+                await expect(insurance.intendToWithdraw()).to.emit(
+                    insurance,
+                    "Cooldown"
                 )
             })
         })
@@ -111,10 +110,8 @@ describe("Unit tests: Insurance.sol", function () {
     describe("cancelWithdraw", async () => {
         context("when user has not called intendToWithdraw", async () => {
             it("reverts", async () => {
-                await expect(
-                    insurance
-                        .cancelWithdraw()
-                        .to.be.revertedWith("INS: Not withdrawing")
+                await expect(insurance.cancelWithdraw()).to.be.revertedWith(
+                    "INS: Not withdrawing"
                 )
             })
         })
@@ -133,8 +130,8 @@ describe("Unit tests: Insurance.sol", function () {
             })
 
             it("resets the users cooldown", async () => {
-                await expect(
-                    insurance.withdrawCooldown(accounts[0].address)
+                expect(
+                    await insurance.withdrawCooldown(accounts[0].address)
                 ).to.equal(0)
             })
 
@@ -149,11 +146,14 @@ describe("Unit tests: Insurance.sol", function () {
     describe("withdraw", async () => {
         context("when the user has not called intendToWithdraw", async () => {
             it("reverts", async () => {
-                await expect(
-                    insurance
-                        .withdraw(ethers.utils.parseEther("1"))
-                        .to.be.revertedWith("INS: Funds locked")
+                await depositToInsurance(
+                    insurance,
+                    quoteToken,
+                    ethers.utils.parseEther("2")
                 )
+                await expect(
+                    insurance.withdraw(ethers.utils.parseEther("2"))
+                ).to.be.revertedWith("INS: Funds locked")
             })
         })
 
@@ -168,10 +168,8 @@ describe("Unit tests: Insurance.sol", function () {
                     )
                     await insurance.intendToWithdraw()
                     await expect(
-                        insurance
-                            .withdraw(ethers.utils.parseEther("1"))
-                            .to.be.revertedWith("INS: Funds locked")
-                    )
+                        insurance.withdraw(ethers.utils.parseEther("1"))
+                    ).to.be.revertedWith("INS: Funds locked")
                 })
             }
         )
@@ -192,7 +190,7 @@ describe("Unit tests: Insurance.sol", function () {
                             await forwardTime(withdrawCooldown)
                             await expect(
                                 insurance.withdraw(ethers.utils.parseEther("5"))
-                            ).to.be.revertedWith("INS: balance < amount")
+                            ).to.be.revertedWith("INS: Balance < amount")
                         })
                     }
                 )
@@ -210,7 +208,7 @@ describe("Unit tests: Insurance.sol", function () {
                         await insurance.intendToWithdraw()
                         await forwardTime(withdrawCooldown)
                         // get user to burn some pool tokens
-                        amount = ethers.utils.paresEther("1")
+                        amount = ethers.utils.parseEther("1")
                         tx = await insurance.withdraw(amount)
                     })
 
@@ -253,8 +251,8 @@ describe("Unit tests: Insurance.sol", function () {
                     await insurance.intendToWithdraw()
                     await forwardTime(withdrawCooldown + withdrawWindow)
                     await expect(
-                        insurance.withdraw(ethers.utils.parseEther("5"))
-                    ).to.be.revertedWith("INS: balance < amount")
+                        insurance.withdraw(ethers.utils.parseEther("2"))
+                    ).to.be.revertedWith("INS: Funds locked")
                 })
             }
         )

--- a/test/unit/InsuranceStaking.js
+++ b/test/unit/InsuranceStaking.js
@@ -5,6 +5,15 @@ const {
     getInsurance,
     getTracer,
 } = require("../util/DeploymentUtil")
+const { depositToInsurance } = require("../util/InsuranceUtil")
+
+const withdrawCooldown = 5 * 86400 // 5 days
+const withdrawWindow = 2 * 86400 // 2 days
+
+const forwardTime = async (seconds) => {
+    await network.provider.send("evm_increaseTime", [seconds])
+    await network.provider.send("evm_mine", [])
+}
 
 const setupTests = deployments.createFixture(async () => {
     await deployments.fixture(["FullDeployTest"])
@@ -74,43 +83,181 @@ describe("Unit tests: Insurance.sol", function () {
         })
     })
 
-    describe("withdraw", async () => {
-        context("when the user does not have enough pool tokens", async () => {
+    describe("intendToWithdraw", async () => {
+        context("when user has zero balance", async () => {
             it("reverts", async () => {
                 await expect(
-                    insurance.withdraw(ethers.utils.parseEther("1"))
-                ).to.be.revertedWith("INS: balance < amount")
+                    insurance
+                        .intendToWithdraw()
+                        .to.be.revertedWith("INS: Zero balance")
+                )
             })
         })
 
-        context("when the user has enough pool tokens", async () => {
+        context("when user has balance", async () => {
+            it("emits event", async () => {
+                await depositToInsurance(
+                    insurance,
+                    quoteToken,
+                    ethers.utils.parseEther("1")
+                )
+                await expect(
+                    insurance.intendToWithdraw().to.emit(insurance, "Cooldown")
+                )
+            })
+        })
+    })
+
+    describe("cancelWithdraw", async () => {
+        context("when user has not called intendToWithdraw", async () => {
+            it("reverts", async () => {
+                await expect(
+                    insurance
+                        .cancelWithdraw()
+                        .to.be.revertedWith("INS: Not withdrawing")
+                )
+            })
+        })
+
+        context("when user has called intendToWithdraw", async () => {
+            let tx
+
             beforeEach(async () => {
-                // get user tp acquire some pool tokens
-                await quoteToken.approve(
-                    insurance.address,
-                    ethers.utils.parseEther("2")
+                await depositToInsurance(
+                    insurance,
+                    quoteToken,
+                    ethers.utils.parseEther("1")
                 )
-                await insurance.deposit(ethers.utils.parseEther("2"))
-                // get user to burn some pool tokens
-                await insurance.withdraw(ethers.utils.parseEther("1"))
+                await insurance.intendToWithdraw()
+                tx = await insurance.cancelWithdraw()
             })
 
-            it("burns pool tokens", async () => {
-                let poolTokenHolding = await insurance.getPoolUserBalance(
-                    accounts[0].address
-                )
-                expect(poolTokenHolding).to.equal(ethers.utils.parseEther("1"))
+            it("resets the users cooldown", async () => {
+                await expect(
+                    insurance.withdrawCooldown(accounts[0].address)
+                ).to.equal(0)
             })
 
-            it("decreases the collateral holdings of the insurance fund", async () => {
-                let collateralHolding = await insurance.publicCollateralAmount()
-                expect(collateralHolding).to.equal(ethers.utils.parseEther("1"))
+            it("resets the users cooldown", async () => {
+                await expect(tx)
+                    .to.emit(insurance, "Cooldown")
+                    .withArgs(accounts[0].address, 0)
             })
-
-            it("pulls in collateral from the tracer market", async () => {})
-
-            it("emits an insurance withdraw event", async () => {})
         })
+    })
+
+    describe("withdraw", async () => {
+        context("when the user has not called intendToWithdraw", async () => {
+            it("reverts", async () => {
+                await expect(
+                    insurance
+                        .withdraw(ethers.utils.parseEther("1"))
+                        .to.be.revertedWith("INS: Funds locked")
+                )
+            })
+        })
+
+        context(
+            "when the user calls intendToWithdraw but cooldown window has not passed",
+            async () => {
+                it("reverts", async () => {
+                    await depositToInsurance(
+                        insurance,
+                        quoteToken,
+                        ethers.utils.parseEther("2")
+                    )
+                    await insurance.intendToWithdraw()
+                    await expect(
+                        insurance
+                            .withdraw(ethers.utils.parseEther("1"))
+                            .to.be.revertedWith("INS: Funds locked")
+                    )
+                })
+            }
+        )
+
+        context(
+            "when the user calls intendToWithdraw and is in withdraw window",
+            async () => {
+                context(
+                    "when the user does not have enough pool tokens",
+                    async () => {
+                        it("reverts", async () => {
+                            await depositToInsurance(
+                                insurance,
+                                quoteToken,
+                                ethers.utils.parseEther("2")
+                            )
+                            await insurance.intendToWithdraw()
+                            await forwardTime(withdrawCooldown)
+                            await expect(
+                                insurance.withdraw(ethers.utils.parseEther("5"))
+                            ).to.be.revertedWith("INS: balance < amount")
+                        })
+                    }
+                )
+
+                context("when the user has enough pool tokens", async () => {
+                    let tx, amount
+
+                    beforeEach(async () => {
+                        // get user tp acquire some pool tokens
+                        await depositToInsurance(
+                            insurance,
+                            quoteToken,
+                            ethers.utils.parseEther("2")
+                        )
+                        await insurance.intendToWithdraw()
+                        await forwardTime(withdrawCooldown)
+                        // get user to burn some pool tokens
+                        amount = ethers.utils.paresEther("1")
+                        tx = await insurance.withdraw(amount)
+                    })
+
+                    it("burns pool tokens", async () => {
+                        let poolTokenHolding =
+                            await insurance.getPoolUserBalance(
+                                accounts[0].address
+                            )
+                        expect(poolTokenHolding).to.equal(amount)
+                    })
+
+                    it("decreases the collateral holdings of the insurance fund", async () => {
+                        let collateralHolding =
+                            await insurance.publicCollateralAmount()
+                        expect(collateralHolding).to.equal(amount)
+                    })
+
+                    it("emits an insurance withdraw event", async () => {
+                        expect(tx)
+                            .to.emit(insurance, "InsuranceWithdraw")
+                            .withArgs(
+                                tracer.address,
+                                accounts[0].address,
+                                amount
+                            )
+                    })
+                })
+            }
+        )
+
+        context(
+            "when the user calls intendToWithdraw and withdraw window has passed",
+            async () => {
+                it("reverts", async () => {
+                    await depositToInsurance(
+                        insurance,
+                        quoteToken,
+                        ethers.utils.parseEther("2")
+                    )
+                    await insurance.intendToWithdraw()
+                    await forwardTime(withdrawCooldown + withdrawWindow)
+                    await expect(
+                        insurance.withdraw(ethers.utils.parseEther("5"))
+                    ).to.be.revertedWith("INS: balance < amount")
+                })
+            }
+        )
     })
 
     describe("getPoolBalance", async () => {

--- a/test/util/InsuranceUtil.js
+++ b/test/util/InsuranceUtil.js
@@ -56,8 +56,14 @@ const setAndDrainCollaterals = async (
     await insurance.drainPool(amountToDrain)
 }
 
+const depositToInsurance = async (insurance, quoteToken, amount) => {
+    await quoteToken.approve(insurance.address, amount)
+    await insurance.deposit(amount)
+}
+
 module.exports = {
     expectCollaterals,
     setCollaterals,
     setAndDrainCollaterals,
+    depositToInsurance,
 }


### PR DESCRIPTION
# Motivation
Delayed insurance withdrawal should be enforced on all withdrawals to prevent sudden draining of the insurance pool.

When a user wants to withdraw from the pool they should first call `intendToWithdraw`. They will then have to wait for the cooldown period to elapse (5 days). Then, they will have a window of time to withdraw (2 days). Once this passes they will have to renotify their intent to withdraw before withdrawing. 

              ┌───────────────────────────────────┬─────────────────────────┐
              │      `COOLDOWN_PERIOD` 5 days     │ `WITHDRAW_WINDOW` 2 days│
              └───────────────────────────────────┴─────────────────────────┘
               ↑                                               ↑ 
               User calls `intendToWithdraw`        User can call `withdraw`
               User can call `cancelWithdraw` to reset cooldown


Note that there is no on-chain bookkeeping for delayed withdrawals, pool collateral is only updated once the user has called `withdraw`.

# Changes
- Add `intendToWithdraw`, `cancelWithdraw` and update `withdraw` functions as above
- Added tests